### PR TITLE
rough-out of llh client/server using TCP IPC for EMCEE parallelization

### DIFF
--- a/pisa/utils/llh_client.py
+++ b/pisa/utils/llh_client.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+"""
+EMCEE-callable cleints for making parallel llh requests to a set of
+`simpler_server`s; each client passes free param values to an available server,
+server sets these on its DistributionMaker, generates outputs, compares the
+resulting distributions against a reference template, and returns the llh value.
+
+`Cleint` code borrowed from Dan Krause
+  https://gist.github.com/dankrause/9607475
+see `__license__`.
+"""
+
+
+from __future__ import absolute_import, division, print_function
+
+
+__author__ = "Dan Krause, adapted by J.L. Lanfranchi"
+
+__license__ = """
+Copyright 2017 Dan Krause
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
+__all__ = ["Client", "get_llh", "setup_sampler", "main"]
+
+
+from argparse import ArgumentParser
+from collections import Mapping
+from itertools import cycle
+from multiprocessing import Manager
+import socket
+import time
+
+import emcee
+import numpy as np
+
+from pisa.utils.llh_server import send_obj, receive_obj
+
+
+class Client(object):
+    def __init__(self, server_address):
+        self.addr = server_address
+        if isinstance(self.addr, basestring):
+            address_family = socket.AF_UNIX
+        else:
+            address_family = socket.AF_INET
+        self.sock = socket.socket(address_family, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+    def connect(self):
+        self.sock.connect(self.addr)
+
+    def close(self):
+        self.sock.close()
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def get_llh(self, x):
+        send_obj(x, self.sock)
+        llh = receive_obj(self.sock)
+        return llh
+
+
+def get_llh(x, server_infos):
+    """Get llh given free param values `x` (name chosen for compatibility with
+    EMCEE) from a `pisa.utils.llh_server` running somewhere, via TCP-based IPC.
+
+    Parameters
+    ----------
+    x : sequence
+        Free param values to set on the DistributionMaker, at which we wich to
+        find llh
+
+    server_infos : dict or iterable thereof
+        Each dict must have fields "host", "port", and "lock"
+
+    Returns
+    -------
+    llh
+
+    """
+    if isinstance(server_infos, Mapping):
+        server_infos = [server_infos]
+
+    # Cycle through all servers/ports forever
+    for server_info in cycle(server_infos):
+        if "lock" in server_info:
+            if server_info["lock"].acquire(blocking=False):
+                try:
+                    with Client((server_info["host"], server_info["port"])) as client:
+                        llh = client.get_llh(x)
+                    print(server_info)
+                    return llh
+                finally:
+                    server_info["lock"].release()
+            else:
+                # don't hammer ports too hard (not sure about sleep time, though)
+                time.sleep(0.1)  # sec
+        else:
+            with Client((server_info["host"], server_info["port"])) as client:
+                llh = client.get_llh(x)
+            return llh
+
+    raise ValueError("No hosts?")
+
+
+def setup_sampler(nwalkers, ndim, host_port_num, **kwargs):
+    """Setup/instantiate an `emcee.EnsembleSampler`.
+
+    Parameters
+    ----------
+    host_port_num : tuple of (host, port, num) or iterable thereof
+
+    nwalkers, ndim, *args, **kwargs
+        Passed onto `emcee.EnsembleSampler`; note that fields
+
+            kwargs["threads"]
+            kwargs["kwargs"]["server_infos"]
+
+        are overwritten by values derived here (if any of these already exist
+        in `kwargs`).
+
+    Returns
+    -------
+    sampler : emcee.EnsembleSampler
+
+    """
+    host_port_num = tuple(host_port_num)
+    if isinstance(host_port_num[0], basestring):
+        host_port_num = (host_port_num,)
+
+    # Construct (lock, host, port) dict per port per host, each with a unique lock
+    manager = Manager()
+    server_infos = []
+    for hpn in host_port_num:
+        host = str(hpn[0])
+        port0 = int(hpn[1])
+        num = int(hpn[2])
+        for port in range(port0, port0 + num):
+            server_infos.append(dict(lock=manager.Lock(), host=host, port=port))
+    threads = len(server_infos)
+
+    sub_kwargs = kwargs.get("kwargs", {})
+    sub_kwargs["server_infos"] = server_infos
+    kwargs["kwargs"] = sub_kwargs
+
+    sampler = emcee.EnsembleSampler(nwalkers, ndim, get_llh, threads=threads, **kwargs)
+
+    return sampler
+
+
+def main(description=__doc__):
+    """Parse command line arguments and execute"""
+    parser = ArgumentParser(description=description)
+    parser.add_argument(
+        "--host-port-num",
+        nargs=3,
+        action="append",
+        metavar="",
+        help="""Provide HOST PORT NUM, separated by spaces; repeat
+        --host-port-num arg for multiple hosts"""
+    )
+
+    kwargs = vars(parser.parse_args())
+    ndim = 3
+    nwalkers = 100
+    sampler = setup_sampler(nwalkers=nwalkers, ndim=ndim, **kwargs)
+
+    rand = np.random.RandomState(0)
+    p0 = rand.rand(ndim * nwalkers).reshape((nwalkers, ndim))
+
+    sampler.run_mcmc(p0, nwalkers)
+
+
+if  __name__ == "__main__":
+    main()

--- a/pisa/utils/llh_server.py
+++ b/pisa/utils/llh_server.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+"""
+Server(s) for handling llh requests from a client: client passes free param
+values, server sets these on its DistributionMaker, generates outputs, and
+compares the resulting distributions against a reference template, returning
+the llh value.
+
+Code adapted from Dan Krause
+  https://gist.github.com/dankrause/9607475
+see `__license__`.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Dan Krause, adapted by J.L. Lanfranchi"
+
+__license__ = """
+Copyright 2017 Dan Krause
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
+__all__ = [
+    "DFLT_HOST",
+    "DFLT_PORT",
+    "DFLT_NUM_SERVERS",
+    "send_obj",
+    "receive_obj",
+    "serve",
+    "fork_servers",
+    "main",
+]
+
+
+from argparse import ArgumentParser
+from multiprocessing import cpu_count, Process
+import pickle
+import SocketServer
+import struct
+
+from pisa.core.distribution_maker import DistributionMaker
+from pisa.core.map import MapSet
+
+
+DFLT_HOST = "localhost"
+DFLT_PORT = "9000"
+DFLT_NUM_SERVERS = cpu_count()
+
+
+class ConnectionClosed(Exception):
+    """Connection closed"""
+    pass
+
+
+def send_obj(obj, sock):
+    """Send a Python object over a socket. Object is pickle-encoded as the
+    payload and sent preceded by a 4-byte header which indicates the number of
+    bytes of the payload.
+
+    Parameters
+    ----------
+    sock : socket
+    obj : pickle-able Python object
+        Object to send
+
+    """
+    # Turn object into a string
+    payload = pickle.dumps(obj)
+
+    # Create a header that says how large the payload is
+    header = struct.pack('!i', len(payload))
+
+    # Send header
+    sock.sendall(header)
+
+    # Send payload
+    sock.sendall(payload)
+
+
+def receive_obj(sock):
+    """Receive an object from a socket. Payload is a pickle-encoded object, and
+    header (prefixing payload) is 4-byte int indicating length of the payload.
+
+    Parameters
+    ----------
+    sock : socket
+
+    Returns
+    -------
+    obj
+        Unpickled Python object
+
+    """
+    # Get 4-byte header which tells how large the subsequent payload will be
+    header = sock.recv(4)
+    if len(header) == 0:
+        raise ConnectionClosed()
+    payload_size = struct.unpack('!i', header)[0]
+
+    # Receive the payload
+    payload = sock.recv(payload_size)
+    if len(payload) == 0:
+        raise ConnectionClosed()
+
+    # Payload was pickled; unpickle to recreate original Python object
+    obj = pickle.loads(payload)
+
+    return obj
+
+
+def serve(config, ref, port=DFLT_PORT):
+    """Instantiate PISA objects and run server for processing requests.
+
+    Parameters
+    ----------
+    config : str or iterable thereof
+        Resource path(s) to pipeline config(s)
+
+    ref : str
+        Resource path to reference map
+
+    port : int or str, optional
+
+    """
+    # Instantiate the objects here to save having to do this repeatedly
+    dist_maker = DistributionMaker(config)
+    ref = MapSet.from_json(ref)
+
+    # Define server as a closure such that it captures the above-instantiated objects
+    class MyTCPHandler(SocketServer.BaseRequestHandler):
+        """
+        The request handler class for our server.
+
+        It is instantiated once per connection to the server, and must override
+        the handle() method to implement communication to the client.
+
+        See SocketServer.BaseRequestHandler for documentation of args.
+        """
+        def handle(self):
+            try:
+                param_values = receive_obj(self.request)
+            except ConnectionClosed:
+                return
+            dist_maker._set_rescaled_free_params(param_values)  # pylint: disable=protected-access
+            test_map = dist_maker.get_outputs(return_sum=True)[0]
+            llh = test_map.llh(
+                expected_values=ref,
+                binned=False,  # return sum over llh from all bins (not per-bin llh's)
+            )
+            send_obj(llh, self.request)
+
+    server = SocketServer.TCPServer((DFLT_HOST, int(port)), MyTCPHandler)
+    print("llh server started on {}:{}".format(DFLT_HOST, port))
+    server.serve_forever()
+
+
+def fork_servers(config, ref, port=DFLT_PORT, num=DFLT_NUM_SERVERS):
+    """Fork multiple servers for handling LLH requests. Objects are identically
+    configured, and ports used are sequential starting from `port`.
+
+    Parameters
+    ----------
+    config : str or iterable thereof
+    ref : str
+    port : str or int, optional
+    num : int, optional
+        Defaults to number of CPUs returned by `multiple.cpu_count()`
+
+    """
+    processes = []
+    for port_ in range(int(port), int(port) + int(num)):
+        kwargs = dict(config=config, ref=ref, port=str(port_))
+        process = Process(target=serve, kwargs=kwargs)
+        processes.append(process)
+
+    # Start all processes
+    for process in processes:
+        process.start()
+
+    # Wait for all processes to finish
+    for process in processes:
+        process.join()
+
+
+def main(description=__doc__):
+    """Parse command line arguments"""
+    parser = ArgumentParser(description=description)
+    parser.add_argument(
+        "--config",
+        nargs="+",
+        help="""Resource location of a pipeline config; repeat --config for
+        multiple pipelines"""
+    )
+    parser.add_argument("--ref", help="Resource location of reference (truth) map")
+    parser.add_argument("--port", default=DFLT_PORT)
+    parser.add_argument(
+        "--num",
+        default=1,
+        type=int,
+        help="Number of servers to fork (>= 1); if set to 1, no forking occurs",
+    )
+    args = parser.parse_args()
+    kwargs = vars(args)
+    num = kwargs.pop("num")
+    if num == 1:
+        serve(**kwargs)
+    else:
+        fork_servers(num=num, **kwargs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is tailored to the EMCEE tool, but the method of parallelizing getting LLH's from PISA distribution makers in parallel could benefit other use cases.