### PR TITLE
Added new LLH methods and reworked the Barlow LLH

### DIFF
--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -1356,6 +1356,59 @@ class Map(object):
 
         return np.sum(stats.llh(actual_values=self.hist,
                                 expected_values=expected_values))
+    
+    def thorsten_llh(self, expected_values, binned=False):
+        """Calculate the total thorsten log-likelihood value between this map and the
+        map described by `expected_values`; self is taken to be the "actual
+        values" (or (pseudo)data), and `expected_values` are the expectation
+        values for each bin.
+
+        Parameters
+        ----------
+        expected_values : numpy.ndarray or Map of same dimension as this
+
+        binned : bool
+
+        Returns
+        -------
+        total_llh : float or binned_llh if binned=True
+
+        """
+        expected_values = reduceToHist(expected_values)
+
+        if binned:
+            return stats.thorsten_llh(actual_values=self.hist,
+                             expected_values=expected_values)
+
+        return np.sum(stats.thorsten_llh(actual_values=self.hist,
+                                expected_values=expected_values))
+
+
+    def say_llh(self, expected_values, binned=False):
+        """Calculate the total SAY log-likelihood value between this map and the
+        map described by `expected_values`; self is taken to be the "actual
+        values" (or (pseudo)data), and `expected_values` are the expectation
+        values for each bin.
+
+        Parameters
+        ----------
+        expected_values : numpy.ndarray or Map of same dimension as this
+
+        binned : bool
+
+        Returns
+        -------
+        total_llh : float or binned_llh if binned=True
+
+        """
+        expected_values = reduceToHist(expected_values)
+
+        if binned:
+            return stats.say_llh(actual_values=self.hist,
+                             expected_values=expected_values)
+
+        return np.sum(stats.say_llh(actual_values=self.hist,
+                                expected_values=expected_values))
 
     def conv_llh(self, expected_values, binned=False):
         """Calculate the total convoluted log-likelihood value between this map

--- a/pisa/utils/likelihood_functions.py
+++ b/pisa/utils/likelihood_functions.py
@@ -26,8 +26,8 @@ def poisson_gamma(data, sum_w, sum_w2, a=1, b=0):
     data = data histogram
     sum_w = MC histogram
     sum_w2 = Uncertainty map (sum of weights squared in each bin)
-    a, b = hyperparameters of gamma prior for MC counts; default values of a = 1 and b = 0 corresponds to SAY LLH (eq 3.16) https://arxiv.org/pdf/1901.04645.pdf
-                                                             a = 0 and b = 0 corresponds to Thorsten LLH (eq 21) https://arxiv.org/pdf/1712.01293.pdf
+    a, b = hyperparameters of gamma prior for MC counts; default values of a = 1 and b = 0 corresponds to SAY LLH (eq 3.16) https://doi.org/10.1007/JHEP06(2019)030
+                                                             a = 0 and b = 0 corresponds to Thorsten LLH (eq 20) https://doi.org/10.1140/epjp/i2018-12042-x
     -- Output --
     llh = LLH values in each bin
 
@@ -78,6 +78,7 @@ def poissonLLH(data, mc):
 def barlowLLH(data, unweighted_mc, weights):
     """
     Barlow-Beeston log-likelihood (constant terms not omitted)
+    Link to paper: https://doi.org/10.1016/0010-4655(93)90005-W
     -- Input variables --
     data = data histogram
     mc = weighted MC histogram

--- a/pisa/utils/likelihood_functions.py
+++ b/pisa/utils/likelihood_functions.py
@@ -1,0 +1,127 @@
+"""
+This script contains functions to compute Barlow-Beeston Likelihood, as well as 
+an implementation of the Poisson-Gamma mixture.
+
+These likelihood implementations take into account uncertainties due to
+finite Monte Carlo statistics.
+
+The functions are called in stats.py to apply them to histograms.
+
+Note that these likelihoods are NOT centered around 0 (i.e. if data == expectation, LLH != 0)
+"""
+
+import numpy as np
+from scipy import special
+from scipy import optimize
+
+__author__ = "Ahnaf Tahmid"
+__email__ = "tahmid@ualberta.ca"
+__date__ = "2019-08-15"
+
+def poisson_gamma(data, sum_w, sum_w2, a=1, b=0):
+    """
+    Log-likelihood based on the poisson-gamma mixture. This is a Poisson likelihood using a Gamma prior.
+    This implementation is based on the implementation of Austin Schneider (aschneider@icecube.wisc.edu)
+    -- Input variables --
+    data = data histogram
+    sum_w = MC histogram
+    sum_w2 = Uncertainty map (sum of weights squared in each bin)
+    a, b = hyperparameters of gamma prior for MC counts; default values of a = 1 and b = 0 corresponds to SAY LLH (eq 3.16) https://arxiv.org/pdf/1901.04645.pdf
+                                                             a = 0 and b = 0 corresponds to Thorsten LLH (eq 21) https://arxiv.org/pdf/1712.01293.pdf
+    -- Output --
+    llh = LLH values in each bin
+
+    -- Notes --
+    Shape of data, sum_w, sum_w2 and llh are identical
+    """
+    
+    llh = np.ones(data.shape) * -np.inf # Binwise LLH values
+
+    bad_bins = np.logical_or(sum_w <= 0, sum_w2 < 0) # Bins where the MC is 0 or less than 0
+    
+    # LLH would be 0 for the bad bins if the data is 0
+    zero_llh = np.logical_and(data == 0, bad_bins) 
+    llh[zero_llh] = 0 # Zero LLH for these bins if data is also 0
+
+    good_bins = ~bad_bins
+    poisson_bins = np.logical_and(sum_w2 == 0, good_bins) # In the limit that sum_w2 == 0, the llh converges to poisson
+    
+    llh[poisson_bins] = poissonLLH(data[poisson_bins], sum_w[poisson_bins]) # Poisson LLH since limiting case
+   
+   # Calculate hyperparameters for the gamma posterior for MC counts
+    regular_bins = np.logical_and(good_bins, ~poisson_bins) # Bins on which the poisson_gamma LLH would be evaluated
+    alpha = sum_w[regular_bins]**2./sum_w2[regular_bins] + a
+    beta = sum_w[regular_bins]/sum_w2[regular_bins] + b
+
+    k = data[regular_bins]
+    # Poisson-gamma LLH
+    L = alpha*np.log(beta) + special.loggamma(k+alpha).real - special.loggamma(k+1.0).real - (k+alpha)*np.log1p(beta) - special.loggamma(alpha).real 
+    llh[regular_bins] = L 
+
+    return llh
+
+def poissonLLH(data, mc):
+    """
+    Standard poisson likelihood
+    -- Input variables --
+    data = data histogram
+    mc = MC histogram
+
+    -- Output --
+    LLH values in each bin
+
+    -- Notes --
+    Shape of data, mc are identical
+    """
+    return data*np.log(mc) - mc - special.loggamma(data + 1)
+
+def barlowLLH(data, unweighted_mc, weights):
+    """
+    Barlow-Beeston log-likelihood (constant terms not omitted)
+    -- Input variables --
+    data = data histogram
+    mc = weighted MC histogram
+    unweighted_mc = unweighted MC histogream
+    weights = weight of each bin
+
+    -- Output --
+    llh = LLH values in each bin
+
+    -- Notes --
+    Shape of data, mc, unweighted_mc, weights and llh must be identical
+    """
+
+    # The actual barlow LLH
+    def llh(A_, k, w, a):
+        SMALL_VAL = 1.e-10
+        
+        f = w*A_
+        
+        # Takes care of log(0) problems
+        if not len(A_) > 1:
+            f = max((f, SMALL_VAL))
+            A_ = max((A_, SMALL_VAL))
+
+        # The loggamma() terms takes care of the log(value!) for non-integer values
+        return -1.*(k*np.log(f) - f + a*np.log(A_) - A_ - special.loggamma(k+1) - special.loggamma(a+1))
+    
+    A = np.array(unweighted_mc) # Expected unweighted counts in a bin
+    # For each bin the appropriate 'A' will now be found using the current counts as a seed
+    # This will be done by using a minimiser to ensure that the value of 'A' found minimises the -LLH
+    
+    # Find values of A such that llh in each bin is a maximum
+    for i, val in enumerate(A):
+        # If the counts in the bin is 0, A = 0
+        if val == 0:
+            continue
+        # Otherwise, find the value of A
+        arg = (data[i], weights[i], unweighted_mc[i])
+        # Powell works fast and is fine for our purposes
+        result = optimize.minimize(fun=llh, x0=val, args=arg, method='Powell')
+        A[i] = result.x
+
+    LLH = llh(A, data, weights, unweighted_mc)
+
+    return -1*LLH # Return LLH (not negative LLH)
+
+

--- a/pisa/utils/likelihood_functions.py
+++ b/pisa/utils/likelihood_functions.py
@@ -111,14 +111,23 @@ def barlowLLH(data, unweighted_mc, weights):
     
     # Find values of A such that llh in each bin is a maximum
     for i, val in enumerate(A):
-        # If the counts in the bin is 0, A = 0
+        # If the unweighted MC counts in the bin is 0, A = 0
         if val == 0:
             continue
         # Otherwise, find the value of A
         arg = (data[i], weights[i], unweighted_mc[i])
         # Powell works fast and is fine for our purposes
         result = optimize.minimize(fun=llh, x0=val, args=arg, method='Powell')
-        A[i] = result.x
+        
+        # Check that the minimisation ran properly
+        if result.success:
+            A[i] = result.x
+        else:
+            print "Something went wrong..."
+            print "Minimiser message: "
+            print "------------------"
+            print result.message
+            return -np.inf
 
     LLH = llh(A, data, weights, unweighted_mc)
 

--- a/pisa/utils/stats.py
+++ b/pisa/utils/stats.py
@@ -13,12 +13,12 @@ from pisa import FTYPE
 from pisa.utils.barlow import Likelihoods
 from pisa.utils.comparisons import FTYPE_PREC, isbarenumeric
 from pisa.utils.log import logging
-
+from pisa.utils import likelihood_functions
 
 __all__ = ['SMALL_POS', 'CHI2_METRICS', 'LLH_METRICS', 'ALL_METRICS',
            'maperror_logmsg',
            'chi2', 'llh', 'log_poisson', 'log_smear', 'conv_poisson',
-           'norm_conv_poisson', 'conv_llh', 'barlow_llh', 'mod_chi2']
+           'norm_conv_poisson', 'conv_llh', 'barlow_llh', 'mod_chi2', 'thorsten_llh', 'say_llh']
 
 __author__ = 'P. Eller, T. Ehrhardt, J.L. Lanfranchi'
 
@@ -43,7 +43,7 @@ SMALL_POS = 1e-10 #if FTYPE == np.float64 else FTYPE_PREC
 CHI2_METRICS = ['chi2', 'mod_chi2']
 """Metrics defined that result in measures of chi squared"""
 
-LLH_METRICS = ['llh', 'conv_llh', 'barlow_llh']
+LLH_METRICS = ['llh', 'conv_llh', 'barlow_llh', 'thorsten_llh', 'say_llh']
 """Metrics defined that result in measures of log likelihood"""
 
 ALL_METRICS = LLH_METRICS + CHI2_METRICS
@@ -212,6 +212,119 @@ def llh(actual_values, expected_values):
 
     return llh_val
 
+def thorsten_llh(actual_values, expected_values):
+    """Compute the log-likelihood (llh) based on eq. 21 - https://arxiv.org/abs/1712.01293
+    accounting for finite MC statistics. It is a good analytical approximation to the 
+    convolutional approach described later in the paper.
+
+    Parameters
+    ----------
+    actual_values, expected_values : numpy.ndarrays of same shape
+
+    Returns
+    -------
+    llh : numpy.ndarray of same shape as the inputs
+        llh corresponding to each pair of elements in `actual_values` and
+        `expected_values`.
+
+    Notes
+    -----
+    * 
+    """
+    assert actual_values.shape == expected_values.shape
+
+    # Convert to simple numpy arrays containing floats
+    actual_values = unp.nominal_values(actual_values).ravel()
+    sigma = unp.std_devs(expected_values).ravel()
+    expected_values = unp.nominal_values(expected_values).ravel() 
+    
+    with np.errstate(invalid='ignore'):
+        # Mask off any nan expected values (these are assumed to be ok)
+        actual_values = np.ma.masked_invalid(actual_values)
+        expected_values = np.ma.masked_invalid(expected_values)
+
+        # Check that new array contains all valid entries
+        if np.any(actual_values < 0):
+            msg = ('`actual_values` must all be >= 0...\n'
+                   + maperror_logmsg(actual_values))
+            raise ValueError(msg)
+
+        # TODO: How should we handle nan / masked values in the "data"
+        # (actual_values) distribution? How about negative numbers?
+
+        # Make sure actual values (aka "data") are valid -- no infs, no nans,
+        # etc.
+        if np.any((actual_values < 0) | ~np.isfinite(actual_values)):
+            msg = ('`actual_values` must be >= 0 and neither inf nor nan...\n'
+                   + maperror_logmsg(actual_values))
+            raise ValueError(msg)
+
+        # Check that new array contains all valid entries
+        if np.any(expected_values < 0.0):
+            msg = ('`expected_values` must all be >= 0...\n'
+                   + maperror_logmsg(expected_values))
+            raise ValueError(msg)
+
+    llh_val = likelihood_functions.poisson_gamma(actual_values, expected_values, sigma**2, a=0, b=0)
+    return llh_val
+
+
+def say_llh(actual_values, expected_values):
+    """Compute the log-likelihood (llh) based on eq. 3.16 - https://arxiv.org/pdf/1901.04645.pdf
+    accounting for finite MC statistics.
+
+    Parameters
+    ----------
+    actual_values, expected_values : numpy.ndarrays of same shape
+
+    Returns
+    -------
+    llh : numpy.ndarray of same shape as the inputs
+        llh corresponding to each pair of elements in `actual_values` and
+        `expected_values`.
+
+    Notes
+    -----
+    * 
+    """
+    assert actual_values.shape == expected_values.shape
+
+    # Convert to simple numpy arrays containing floats
+    actual_values = unp.nominal_values(actual_values).ravel()
+    sigma = unp.std_devs(expected_values).ravel()
+    expected_values = unp.nominal_values(expected_values).ravel() 
+    
+    with np.errstate(invalid='ignore'):
+        # Mask off any nan expected values (these are assumed to be ok)
+        actual_values = np.ma.masked_invalid(actual_values)
+        expected_values = np.ma.masked_invalid(expected_values)
+
+        # Check that new array contains all valid entries
+        if np.any(actual_values < 0):
+            msg = ('`actual_values` must all be >= 0...\n'
+                   + maperror_logmsg(actual_values))
+            raise ValueError(msg)
+
+        # TODO: How should we handle nan / masked values in the "data"
+        # (actual_values) distribution? How about negative numbers?
+
+        # Make sure actual values (aka "data") are valid -- no infs, no nans,
+        # etc.
+        if np.any((actual_values < 0) | ~np.isfinite(actual_values)):
+            msg = ('`actual_values` must be >= 0 and neither inf nor nan...\n'
+                   + maperror_logmsg(actual_values))
+            raise ValueError(msg)
+
+        # Check that new array contains all valid entries
+        if np.any(expected_values < 0.0):
+            msg = ('`expected_values` must all be >= 0...\n'
+                   + maperror_logmsg(expected_values))
+            raise ValueError(msg)
+
+    llh_val = likelihood_functions.poisson_gamma(actual_values, expected_values, sigma**2, a=1, b=0)
+    return llh_val
+
+
 
 def log_poisson(k, l):
     r"""Calculate the log of a poisson pdf
@@ -357,7 +470,6 @@ def conv_llh(actual_values, expected_values):
         total -= np.log(max(SMALL_POS, norm_conv_poisson(*norm_triplets[i])))
     return total
 
-
 def barlow_llh(actual_values, expected_values):
     """Compute the Barlow LLH taking into account finite statistics.
 
@@ -367,24 +479,19 @@ def barlow_llh(actual_values, expected_values):
 
     Returns
     -------
-    barlow_llh
+    barlow_llh: numpy.ndarray
 
     """
-    likelihoods = Likelihoods()
+    
     actual_values = unp.nominal_values(actual_values).ravel()
-    sigmas = [unp.std_devs(ev.ravel()) for ev in expected_values]
-    expected_values = [unp.nominal_values(ev).ravel() for ev in expected_values]
-    unweighted = np.array(
-        [(ev/s)**2 for ev, s in zip(expected_values, sigmas)]
-    )
-    weights = np.array(
-        [s**2/ev for ev, s in zip(expected_values, sigmas)]
-    )
-    likelihoods.set_data(actual_values)
-    likelihoods.set_mc(weights)
-    likelihoods.set_unweighted(unweighted)
-    return -likelihoods.get_llh(llh_type='barlow')
+    sigmas = unp.std_devs(expected_values).ravel()
+    expected_values = unp.nominal_values(expected_values).ravel()
 
+    unweighted = np.array([(ev/s)**2 for ev, s in zip(expected_values, sigmas)])
+    weights = np.array([s**2/ev for ev, s in zip(expected_values, sigmas)])
+
+    llh = likelihood_functions.barlowLLH(actual_values, unweighted, weights)
+    return llh
 
 def mod_chi2(actual_values, expected_values):
     """Compute the chi-square value taking into account uncertainty terms

--- a/pisa/utils/stats.py
+++ b/pisa/utils/stats.py
@@ -212,7 +212,7 @@ def llh(actual_values, expected_values):
     return llh_val
 
 def thorsten_llh(actual_values, expected_values):
-    """Compute the log-likelihood (llh) based on eq. 21 - https://arxiv.org/abs/1712.01293
+    """Compute the log-likelihood (llh) based on eq. 20 - https://doi.org/10.1140/epjp/i2018-12042-x
     accounting for finite MC statistics. It is a good analytical approximation to the 
     convolutional approach described later in the paper.
 
@@ -269,7 +269,7 @@ def thorsten_llh(actual_values, expected_values):
 
 
 def say_llh(actual_values, expected_values):
-    """Compute the log-likelihood (llh) based on eq. 3.16 - https://arxiv.org/pdf/1901.04645.pdf
+    """Compute the log-likelihood (llh) based on eq. 3.16 - https://doi.org/10.1007/JHEP06(2019)030
     accounting for finite MC statistics.
 
     Parameters
@@ -471,7 +471,7 @@ def conv_llh(actual_values, expected_values):
 
 def barlow_llh(actual_values, expected_values):
     """Compute the Barlow LLH taking into account finite statistics.
-
+    The likelihood is described in this paper: https://doi.org/10.1016/0010-4655(93)90005-W
     Parameters
     ----------
     actual_values, expected_values : numpy.ndarrays of same shape


### PR DESCRIPTION
SAY LLH and Thorsten LLH added (check `likelihood_functions.py` for reference to the respective papers). The Barlow LLH which was implemented doesn't work since it was old code ported from oscFit. So I rewrote it in `likelihood_functions.py`. `barlow.py` is now unnecessary.