### PR TITLE
Fix #543: integers/arrays thereof: to/from json, comparisons

### DIFF
--- a/pisa/analysis/nutau_analysis.py
+++ b/pisa/analysis/nutau_analysis.py
@@ -234,13 +234,13 @@ class Analysis(object):
 
         # Assess the fit of the template to the data distribution, and negate
         # if necessary
-        #print [map.name for map in template[0]]
-        #print [map.name for map in self.pseudodata]
+        #print([map.name for map in template[0]])
+        #print([map.name for map in self.pseudodata])
         metric_val = (
             self.pseudodata.metric_total(expected_values=template, metric=self.metric)
             + template_maker.params.priors_penalty(metric=self.metric)
         )
-        #print metric_val
+        #print(metric_val)
 
         mod_chi2_val = (self.pseudodata.metric_total(expected_values=template, metric='mod_chi2')
             + template_maker.params.priors_penalty(metric='mod_chi2'))

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -86,11 +86,11 @@ def basename(n):
 
     Examples
     --------
-    >>> print basename('true_energy')
+    >>> print(basename('true_energy'))
     'energy'
-    >>> print basename('Reconstructed coszen')
+    >>> print(basename('Reconstructed coszen'))
     'coszen'
-    >>> print basename('energy___truth')
+    >>> print(basename('energy___truth'))
     'energy'
 
     """
@@ -106,12 +106,10 @@ def basename(n):
     return n
 
 
-def is_binning(something) :
-    '''
-    Return True if argument is a PISA binning (of any dimension), 
-    False otherwise
-    '''
-    return isinstance(something,(OneDimBinning,MultiDimBinning))
+def is_binning(something):
+    """Return True if argument is a PISA binning (of any dimension), False
+    otherwise"""
+    return isinstance(something, (OneDimBinning, MultiDimBinning))
 
 
 # TODO: generalize to any object and move this to a centralized utils location
@@ -203,14 +201,14 @@ class OneDimBinning(object):
     >>> from pisa.core.binning import OneDimBinning
     >>> ebins = OneDimBinning(name='energy', is_log=True,
     ...                       num_bins=40, domain=[1, 80]*ureg.GeV)
-    >>> print ebins
+    >>> print(ebins)
     OneDimBinning('energy', 40 logarithmically-uniform bins spanning [1.0, 80.0] GeV)
     >>> ebins2 = ebins.to('joule')
-    >>> print ebins2
+    >>> print(ebins2)
     OneDimBinning('energy', 40 logarithmically-uniform bins spanning [1.60217653e-10, 1.281741224e-08] J)
     >>> czbins = OneDimBinning(name='coszen',
     ...                        is_lin=True, num_bins=4, domain=[-1, 0])
-    >>> print czbins
+    >>> print(czbins)
     OneDimBinning('coszen', 4 equally-sized bins spanning [-1.0, 0.0])
     >>> czbins2 = OneDimBinning(name='coszen',
     ...                         bin_edges=[-1, -0.75, -0.5, -0.25, 0])
@@ -230,7 +228,7 @@ class OneDimBinning(object):
         if not isinstance(name, str):
             raise TypeError('`name` must be a string; got "%s".' %type(name))
         if domain is not None:
-            assert isinstance(domain, Iterable) or ( isinstance(domain,ureg.Quantity) and domain.size > 1 )
+            assert isinstance(domain, Iterable) or (isinstance(domain, ureg.Quantity) and domain.size > 1)
         if bin_names is not None:
             if isinstance(bin_names, str):
                 bin_names = (bin_names,)
@@ -244,7 +242,7 @@ class OneDimBinning(object):
                     ' nonzero-length strings.'
                 )
         if bin_edges is not None:
-            assert isinstance(bin_edges, Iterable) or ( isinstance(bin_edges,ureg.Quantity) and bin_edges.size > 1 )
+            assert isinstance(bin_edges, Iterable) or (isinstance(bin_edges, ureg.Quantity) and bin_edges.size > 1)
         if is_lin is not None:
             assert isinstance(is_lin, bool)
         if is_log is not None:
@@ -1423,26 +1421,26 @@ class MultiDimBinning(object):
     >>> czbins = OneDimBinning(name='coszen',
     ...                        is_lin=True, num_bins=4, domain=[-1, 0])
     >>> mdb = ebins * czbins
-    >>> print mdb
+    >>> print(mdb)
     MultiDimBinning(
             OneDimBinning('energy', 40 logarithmically-uniform bins spanning [1.0, 80.0] GeV),
             OneDimBinning('coszen', 4 equally-sized bins spanning [-1.0, 0.0])
     )
-    >>> print mdb.energy
+    >>> print(mdb.energy)
     OneDimBinning(name=OneDimBinning('energy', 40 logarithmically-uniform bins spanning [1.0, 80.0] GeV))
-    >>> print mdb[0, 0]
+    >>> print(mdb[0, 0])
     MultiDimBinning(
             OneDimBinning('energy', 1 bin with edges at [1.0, 1.11577660129] GeV (behavior is logarithmic)),
             OneDimBinning('coszen', 1 bin with edges at [-1.0, -0.75] (behavior is linear))
     )
-    >>> print mdb.slice(energy=2)
+    >>> print(mdb.slice(energy=2))
     MultiDimBinning(
             OneDimBinning('energy', 1 bin with edges at [1.24495742399, 1.38909436329] GeV (behavior is logarithmic)),
             OneDimBinning('coszen', 4 equally-sized bins spanning [-1.0, 0.0])
     )
     >>> smaller_binning = mdb[0:2, 0:3]
     >>> map = smaller_binning.ones(name='my_map')
-    >>> print map
+    >>> print(map)
     Map(name='my_map',
         tex='{\\rm my\\_map}',
         full_comparison=False,
@@ -1922,23 +1920,23 @@ class MultiDimBinning(object):
         >>> czbins = OneDimBinning(name='coszen',
         ...                        is_lin=True, num_bins=4, domain=[-1, 0])
         >>> mdb = ebins * czbins
-        >>> print mdb.indexer(energy=0)
+        >>> print(mdb.indexer(energy=0))
         (0, slice(None, None, None))
 
         Omitting a dimension (coszen in the above) is equivalent to slicing
         with a colon (i.e., `(0, slice(None))`):
 
-        >>> print mdb.indexer(energy=0, coszen=slice(None))
+        >>> print(mdb.indexer(energy=0, coszen=slice(None)))
         (0, slice(None, None, None))
 
-        >>> print mdb.indexer(energy=slice(None), coszen=1)
+        >>> print(mdb.indexer(energy=slice(None), coszen=1))
         (slice(None, None, None), 1)
 
         Now create an indexer to use on a Numpy array:
 
         >>> x = np.random.RandomState(0).uniform(size=mdb.shape)
         >>> indexer = mdb.indexer(energy=slice(0, 5), coszen=1)
-        >>> print x[indexer]
+        >>> print(x[indexer])
         [ 0.71518937  0.64589411  0.38344152  0.92559664  0.83261985]
 
         """
@@ -2157,7 +2155,7 @@ class MultiDimBinning(object):
         >>> b0 = MultiDimBinning(...)
         >>> b1 = MultiDimBinning(...)
         >>> b2 = b0.reorder_dimensions(b1)
-        >>> print b2.binning.names
+        >>> print(b2.binning.names)
 
         """
         if hasattr(order, 'binning') and isinstance(order.binning,
@@ -2270,17 +2268,17 @@ class MultiDimBinning(object):
 
         The following are all equivalent:
 
-        >>> print mdb.oversample(2)
+        >>> print(mdb.oversample(2))
         MultiDimBinning(
                 OneDimBinning('x', 4 equally-sized bins spanning [0.0, 2.0]),
                 OneDimBinning('y', 2 equally-sized bins spanning [0.0, 20.0])
         )
-        >>> print mdb.oversample(2, 2)
+        >>> print(mdb.oversample(2, 2))
         MultiDimBinning(
                 OneDimBinning('x', 4 equally-sized bins spanning [0.0, 2.0]),
                 OneDimBinning('y', 2 equally-sized bins spanning [0.0, 20.0])
         )
-        >>> print mdb.oversample(x=2, y=2)
+        >>> print(mdb.oversample(x=2, y=2))
         MultiDimBinning(
                 OneDimBinning('x', 4 equally-sized bins spanning [0.0, 2.0]),
                 OneDimBinning('y', 2 equally-sized bins spanning [0.0, 20.0])
@@ -2289,7 +2287,7 @@ class MultiDimBinning(object):
         But with kwargs, you can specify only the dimensions you want to
         oversample, and the other dimension(s) remain unchanged:
 
-        >>> print mdb.oversample(y=5)
+        >>> print(mdb.oversample(y=5))
         MultiDimBinning([
                 OneDimBinning('x', 2 equally-sized bins spanning [0, 2])),
                 OneDimBinning('y', 5 equally-sized bins spanning [0.0, 20.0]))])
@@ -2771,7 +2769,7 @@ def test_OneDimBinning():
     import shutil
     import tempfile
     # needed so that eval(repr(b)) works
-    from numpy import array, float32, float64 # pylint: disable=unused-variable
+    from numpy import array, float32, float64 # pylint: disable=unused-import
 
     b1 = OneDimBinning(name='true_energy', num_bins=40, is_log=True,
                        domain=[1, 80]*ureg.GeV, tex=r'E_{\rm true}',
@@ -2907,7 +2905,7 @@ def test_MultiDimBinning():
     import tempfile
     import time
     # needed so that eval(repr(mdb)) works
-    from numpy import array, float32, float64 # pylint: disable=unused-variable
+    from numpy import array, float32, float64 # pylint: disable=unused-import
 
     b1 = OneDimBinning(name='energy', num_bins=40, is_log=True,
                        domain=[1, 80]*ureg.GeV)

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -584,7 +584,7 @@ class OneDimBinning(object):
                 assert self.bin_names is not None
                 return self.bin_names.index(x)
             if isinstance(x, int):
-                assert x >= 0 and x < len(self)
+                assert 0 <= x < len(self)
                 return x
             raise TypeError('`x` must be either int or string; got %s instead.'
                             % type(x))
@@ -898,7 +898,7 @@ class OneDimBinning(object):
     def bin_widths(self):
         """Absolute widths of bins."""
         if self._bin_widths is None:
-            self._bin_widths = np.abs(np.diff(self.bin_edges)) * self.units
+            self._bin_widths = np.abs(np.diff(self.bin_edges.m)) * self.units
         return self._bin_widths
 
     @property
@@ -927,7 +927,7 @@ class OneDimBinning(object):
     def __mul__(self, other):
         if isinstance(other, OneDimBinning):
             return MultiDimBinning([self, other])
-        elif isinstance(other, MultiDimBinning):
+        if isinstance(other, MultiDimBinning):
             return MultiDimBinning(chain([self], other))
         return OneDimBinning(name=self.name, tex=self.tex,
                              bin_edges=self.bin_edges * other)
@@ -971,6 +971,8 @@ class OneDimBinning(object):
         bool
 
         """
+        if hasattr(bin_edges, 'magnitude'):
+            bin_edges = bin_edges.magnitude
         bin_edges = np.asarray(bin_edges)
         if len(bin_edges) < 3:
             raise ValueError('%d bin edge(s) passed; require at least 3 to'
@@ -1006,6 +1008,8 @@ class OneDimBinning(object):
         ValueError if fewer than 2 `bin_edges` are specified.
 
         """
+        if hasattr(bin_edges, 'magnitude'):
+            bin_edges = bin_edges.magnitude
         bin_edges = np.array(bin_edges)
         if len(bin_edges) == 1:
             raise ValueError('Single bin edge passed; require at least 2 to'
@@ -1531,7 +1535,7 @@ class MultiDimBinning(object):
     @property
     def _map_class(self):
         if self.__map_class is None:
-            from pisa.core.map import Map
+            from pisa.core.map import Map  # pylint: disable=import-outside-toplevel
             self.__map_class = Map
         return self.__map_class
 
@@ -2477,13 +2481,13 @@ class MultiDimBinning(object):
         """
         entity = entity.lower().strip()
         if entity == 'midpoints':
-            arrays = tuple(d.midpoints for d in self.iterdims())
+            arrays = tuple(d.midpoints.m for d in self.iterdims())
         elif entity == 'weighted_centers':
-            arrays = tuple(d.weighted_centers for d in self.iterdims())
+            arrays = tuple(d.weighted_centers.m for d in self.iterdims())
         elif entity == 'bin_edges':
-            arrays = tuple(d.bin_edges for d in self.iterdims())
+            arrays = tuple(d.bin_edges.m for d in self.iterdims())
         elif entity == 'bin_widths':
-            arrays = tuple(d.bin_widths for d in self.iterdims())
+            arrays = tuple(d.bin_widths.m for d in self.iterdims())
         else:
             raise ValueError('Unrecognized `entity`: "%s"' % entity)
 
@@ -2761,7 +2765,7 @@ class MultiDimBinning(object):
 
 def test_OneDimBinning():
     """Unit tests for OneDimBinning class"""
-    # pylint: disable=line-too-long
+    # pylint: disable=line-too-long, import-outside-toplevel
     import pickle
     import os
     import shutil
@@ -2880,9 +2884,10 @@ def test_OneDimBinning():
 
             # Now try with pickle
             b_file = os.path.join(testdir, 'one_dim_binning.pkl')
-            pickle.dump(struct, open(b_file, 'wb'),
-                        protocol=pickle.HIGHEST_PROTOCOL)
-            loaded = pickle.load(open(b_file, 'rb'))
+            with open(b_file, 'wb') as fobj:
+                pickle.dump(struct, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+            with open(b_file, 'rb') as fobj:
+                loaded = pickle.load(fobj)
             b_ = loaded[0][0]['odb']
             assert b_ == b
 
@@ -2897,6 +2902,7 @@ def test_OneDimBinning():
 
 def test_MultiDimBinning():
     """Unit tests for MultiDimBinning class"""
+    # pylint: disable=import-outside-toplevel
     import pickle
     import os
     import shutil
@@ -2985,8 +2991,9 @@ def test_MultiDimBinning():
         assert b_ == binning, 'binning=\n%s\nb_=\n%s' %(binning, b_)
 
         # Had bug where datastruct containing MultiDimBinning failed to be
-        # saved. # Test tuple containing list containing OrderedDict
-        # containing MultiDimBinning here.
+        # saved. Test tuple containing list containing OrderedDict
+        # containing MultiDimBinning here, just to make sure MultiDimBinning
+        # can be written inside a nested structure.
         b = binning
         struct = ([OrderedDict(mdb=b)],)
         jsons.to_json(struct, b_file, warn=False)
@@ -2996,9 +3003,10 @@ def test_MultiDimBinning():
 
         # Now try with pickle
         b_file = os.path.join(testdir, 'multi_dim_binning.pkl')
-        pickle.dump(struct, open(b_file, 'wb'),
-                    protocol=pickle.HIGHEST_PROTOCOL)
-        loaded = pickle.load(open(b_file, 'rb'))
+        with open(b_file, 'wb') as fobj:
+            pickle.dump(struct, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(b_file, 'rb') as fobj:
+            loaded = pickle.load(fobj)
         b_ = loaded[0][0]['mdb']
         assert b_ == b
 

--- a/pisa/core/container.py
+++ b/pisa/core/container.py
@@ -544,7 +544,7 @@ def test_container():
     binning_x = OneDimBinning(name='x', num_bins=10, is_lin=True, domain=[0, 100])
     binning_y = OneDimBinning(name='y', num_bins=10, is_lin=True, domain=[0, 100])
     binning = MultiDimBinning([binning_x, binning_y])
-    #print binning.names
+    #print(binning.names)
     print(container.get_binned_data('x', binning).get('host'))
     print(Container.unroll_binning('x', binning).get('host'))
 

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -10,7 +10,7 @@ containers but that get passed down to operate on the contained data.
 from __future__ import absolute_import, division
 
 from collections.abc import Iterable, Mapping, Sequence
-from collections import OrderedDict 
+from collections import OrderedDict
 from copy import deepcopy, copy
 from fnmatch import fnmatch
 from functools import reduce
@@ -204,7 +204,6 @@ def _new_obj(original_function):
     return decorate(original_function, new_function)
 
 
-
 def valid_nominal_values(data_array):
     """Get the the nominal values that are valid for an array"""
     return np.ma.masked_invalid(unp.nominal_values(data_array))
@@ -281,10 +280,10 @@ class Map(object):
            [ 1.,  0.],
            [ 1.,  0.]])
     >>> for bin in m1.iterbins():
-    ...     print '({0:~.2f}, {1:~.2f}): {2:0.1f}'.format(
+    ...     print('({0:~.2f}, {1:~.2f}): {2:0.1f}'.format(
     ...             bin.binning.energy.midpoints[0],
     ...             bin.binning.coszen.midpoints[0],
-    ...             bin.hist[0, 0])
+    ...             bin.hist[0, 0]))
     (2.00 GeV, -0.90 ): 1.0
     (2.00 GeV, -0.70 ): 0.0
     (5.97 GeV, -0.90 ): 1.0
@@ -413,7 +412,7 @@ class Map(object):
         ...     dict(name='y', domain=[1,2], is_lin=True, num_bins=10)
         ... ])
         >>> ones = mdb.ones(name='ones')
-        >>> print ones.slice(x=0,)
+        >>> print(ones.slice(x=0,))
         Map(name='ones',
                 tex='{\\rm ones}',
                 full_comparison=False,
@@ -423,9 +422,9 @@ class Map(object):
                             OneDimBinning(name=OneDimBinning('x', 1 bin with edges at [0.0, 0.2] (behavior is linear))),
                             OneDimBinning(name=OneDimBinning('y', 10 equally-sized bins spanning [1.0, 2.0]))]),
                 hist=array([[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]]))
-        >>> print ones.slice(x=0, y=slice(None)).hist
+        >>> print(ones.slice(x=0, y=slice(None)).hist)
         [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]]
-        >>> print ones.slice(x=0, y=0).hist
+        >>> print(ones.slice(x=0, y=0).hist)
         [[ 1.]]
 
         Modifications to the slice modifies the original:
@@ -437,8 +436,8 @@ class Map(object):
         >>> ones = mdb.ones(name='ones')
         >>> sl = ones.slice(x=2)
         >>> sl.hist[...] = 0
-        >>> print sl.hist
-        >>> print ones.hist
+        >>> print(sl.hist)
+        >>> print(ones.hist)
         [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
          [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
          [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
@@ -633,7 +632,7 @@ class Map(object):
              Custom filename to set for saved figure. If not provided, a name
              is derived from the `name` attribute of the Map. Note that if
              `fmt` is None, then this argument is irrelevant.
-        
+
         binlabel_format : string, optional
             Format string to label the content in each bin. If None (default), the bins will not
             be labeled.
@@ -1161,11 +1160,14 @@ class Map(object):
         """
         for i in range(self.size):
             idx_coord = self.binning.index2coord(i)
-            idx_view = [slice(x, x+1) for x in idx_coord]
+            idx_view = tuple(slice(x, x+1) for x in idx_coord)
             single_bin_map = Map(
-                name=self.name, hist=self.hist[idx_view],
-                binning=self.binning[idx_coord], hash=None, tex=self.tex,
-                full_comparison=self.full_comparison
+                name=self.name,
+                hist=self.hist[idx_view],
+                binning=self.binning[idx_coord],
+                hash=None,
+                tex=self.tex,
+                full_comparison=self.full_comparison,
             )
             single_bin_map.parent_indexer = idx_coord
             yield single_bin_map
@@ -1358,7 +1360,7 @@ class Map(object):
 
         return np.sum(stats.llh(actual_values=self.hist,
                                 expected_values=expected_values))
-    
+
     def mcllh_mean(self, expected_values, binned=False):
         """Calculate the total LMean log-likelihood value between this map and the
         map described by `expected_values`; self is taken to be the "actual
@@ -2547,9 +2549,9 @@ class MapSet(object):
         return name in [m.name for m in self]
 
     #def __setattr__(self, attr, val):
-    #    print '__setattr__ being accessed, attr = %s, val = %s' %(attr, val)
+    #    print('__setattr__ being accessed, attr = %s, val = %s' %(attr, val))
     #    if attr in MapSet.__slots:
-    #        print 'attr "%s" found in MapSet.slots.' %attr
+    #        print('attr "%s" found in MapSet.slots.' %attr)
     #        object.__setattr__(self, attr, val)
     #    else:
     #        returned_vals = [setattr(mp, attr, val) for mp in self]
@@ -2803,7 +2805,7 @@ class MapSet(object):
 #                  '__getitem__', '__eq__', '__ne__', '__str__', '__repr__')
 #    if method_name in disallowed:
 #        continue
-#    print 'adding method "%s" to MapSet as an apply func' % method_name
+#    print('adding method "%s" to MapSet as an apply func' % method_name)
 #    arg_str = ', *args' # if len(args) > 0 else ''
 #    eval(('def {method_name}(self{arg_str}):\n'
 #          '    return self.apply_to_maps({method_name}{arg_str})')

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -2760,7 +2760,7 @@ class MapSet(object):
                              % (metric, stats.ALL_METRICS))
 
     def metric_total(self, expected_values, metric):
-        return np.sum(self.metric_per_map(expected_values, metric).values())
+        return np.sum(list(self.metric_per_map(expected_values, metric).values()))
 
     def chi2_per_map(self, expected_values):
         return self.apply_to_maps('chi2', expected_values)

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -24,6 +24,7 @@ import tempfile
 from decorator import decorate
 import numpy as np
 from scipy.stats import poisson, norm
+from six import string_types
 import uncertainties
 from uncertainties import ufloat
 from uncertainties import unumpy as unp
@@ -672,7 +673,7 @@ class Map(object):
         pcolormesh_kw = {} if pcolormesh_kw is None else pcolormesh_kw
         colorbar_kw = {} if colorbar_kw is None else colorbar_kw
         if fmt is not None:
-            if isinstance(fmt, str):
+            if isinstance(fmt, string_types):
                 fmt = [fmt]
             fmt = set(f.strip().lower().lstrip('.') for f in fmt)
             if outdir is None:
@@ -706,7 +707,7 @@ class Map(object):
                 vmax_ = np.abs(vmax)
             elif vmin is not None and vmax is None:
                 vmax_ = np.abs(vmin)
-            else:
+            else:  # neither vmax nor vmin are None
                 assert vmax > vmin and vmax == -vmin
                 vmax_ = vmax
             vmin_ = -vmax_
@@ -854,7 +855,7 @@ class Map(object):
         """
         if axis is None:
             axis = self.binning.names
-        if isinstance(axis, (str, int)):
+        if isinstance(axis, (string_types, int)):
             axis = [axis]
         # Note that the tuple is necessary here (I think...)
         sum_indices = tuple([self.binning.index(dim) for dim in axis])
@@ -1282,7 +1283,7 @@ class Map(object):
 
         singleton = False
         if bin is not None:
-            if isinstance(bin, (int, str)):
+            if isinstance(bin, (int, string_types)):
                 bin_indices = [spliton_dim.index(bin)]
             elif isinstance(bin, slice):
                 bin_indices = list(range(len(spliton_dim)))[bin]
@@ -1543,7 +1544,7 @@ class Map(object):
     @name.setter
     def name(self, value):
         """map name"""
-        assert isinstance(value, str)
+        assert isinstance(value, string_types)
         return super().__setattr__('_name', value)
 
     @property
@@ -1555,7 +1556,7 @@ class Map(object):
 
     @tex.setter
     def tex(self, value):
-        assert value is None or isinstance(value, str)
+        assert value is None or isinstance(value, string_types)
         if value is not None:
             value = strip_outer_dollars(value)
         return super().__setattr__('_tex', value)
@@ -2081,7 +2082,7 @@ class MapSet(object):
                 assert x >= -l and x < l
             elif isinstance(x, Map):
                 x = self.names.index(x.name)
-            elif isinstance(x, str):
+            elif isinstance(x, string_types):
                 x = self.names.index(x)
             else:
                 raise TypeError('Unhandled type "%s" for `x`' % type(x))
@@ -2194,7 +2195,7 @@ class MapSet(object):
 
         """
         is_scalar = False
-        if isinstance(regexes, (str, re.Pattern)):
+        if isinstance(regexes, string_types) or hasattr(regexes, 'pattern'):
             is_scalar = True
             regexes = [regexes]
 
@@ -2294,7 +2295,7 @@ class MapSet(object):
 
         """
         is_scalar = False
-        if isinstance(expressions, str):
+        if isinstance(expressions, string_types):
             is_scalar = True
             expressions = [expressions]
 
@@ -2450,7 +2451,7 @@ class MapSet(object):
         idx = None
         if isinstance(value, Map):
             pass
-        elif isinstance(value, str):
+        elif isinstance(value, string_types):
             try:
                 idx = self.names.index(value)
             except ValueError:
@@ -2506,7 +2507,7 @@ class MapSet(object):
             for arg in args:
                 if (np.isscalar(arg) or
                         type(arg) is uncertainties.core.Variable or
-                        isinstance(arg, (str, np.ndarray))):
+                        isinstance(arg, (string_types, np.ndarray))):
                     this_map_args.append(arg)
                 elif isinstance(arg, MapSet):
                     if self.collate_by_name:
@@ -2581,7 +2582,7 @@ class MapSet(object):
             in an ordered dict with format {<map name>: <values>, ...}
 
         """
-        if isinstance(item, str):
+        if isinstance(item, string_types):
             return self.find_map(item)
 
         if isinstance(item, (int, slice)):
@@ -2745,7 +2746,7 @@ class MapSet(object):
                       collate_by_name=self.collate_by_name)
 
     def metric_per_map(self, expected_values, metric):
-        if isinstance(metric, str):
+        if isinstance(metric, string_types):
             metric = metric.lower()
             if 'binned_' in metric:
                 metric = metric.replace('binned_', '')

--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -19,6 +19,7 @@ import tempfile
 
 import numpy as np
 import pint
+from six import string_types
 
 from pisa import ureg
 from pisa.core.prior import Prior
@@ -226,8 +227,10 @@ class Param:
 
     @value.setter
     def value(self, val):
-        # A number with no units actually has units of "dimensionless"
-        val = interpret_quantity(val, expect_sequence=False)
+        # Strings are simply strings
+        if not isinstance(val, string_types):
+            # A number with no units actually has units of "dimensionless"
+            val = interpret_quantity(val, expect_sequence=False)
         if self._value is not None:
             if hasattr(self._value, 'units'):
                 assert hasattr(val, 'units'), \
@@ -345,7 +348,8 @@ class Param:
 
     @nominal_value.setter
     def nominal_value(self, value):
-        value = interpret_quantity(value, expect_sequence=False)
+        if not isinstance(value, string_types):
+            value = interpret_quantity(value, expect_sequence=False)
         self.validate_value(value)
         self._nominal_value = value
 
@@ -1077,7 +1081,9 @@ class ParamSet(Sequence):
         if isinstance(state, Mapping):
             return cls(*tuple(state.values()))
         raise TypeError(
-            'Unhandled type loaded from "{}": {}'.format(filename, type(state))
+            'Unhandled type loaded from "{}": {}\n{}'.format(
+                filename, type(state), state
+            )
         )
 
 

--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -507,7 +507,7 @@ class Param:
         """Serialize the state to a JSON file that can be instantiated as a new
         object later.
         """
-        jsons.to_json(self.serializable_state, filename, **kwargs)
+        jsons.to_json(self.serializable_state, filename=filename, **kwargs)
 
     @classmethod
     def from_json(cls, filename):

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -494,14 +494,14 @@ def test_histogram():
     binning_y = OneDimBinning(name='y', num_bins=10, is_lin=True, domain=[0, 100])
     binning = MultiDimBinning([binning_x, binning_y])
 
-    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=False)
+    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=False).get()
     assert np.array_equal(
         histo.reshape(10, 10),
         np.diag(np.full(shape=10, fill_value=10))
-    )
+    ), str(histo.reshape(10, 10))
 
-    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=True)
-    assert np.array_equal(histo.reshape(10, 10), np.diag(np.ones(10)))
+    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=True).get()
+    assert np.array_equal(histo.reshape(10, 10), np.diag(np.ones(10))), str(histo.reshape(10, 10))
 
     logging.info('<< PASS : test_histogram >>')
 

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -1,7 +1,7 @@
 # pylint: disable = unsubscriptable-object, too-many-function-args, not-callable, unexpected-keyword-arg, no-value-for-parameter
-'''
-module for data representation translation methods
-'''
+"""
+Module for data representation translation methods
+"""
 
 # TODO:
 #    - right now we distinguish on histogramming/lookup for scalars (normal) or array, which means that instead
@@ -16,25 +16,25 @@ from numba import guvectorize, SmartArray, cuda
 
 from pisa import FTYPE, TARGET
 from pisa.core.binning import OneDimBinning, MultiDimBinning
+from pisa.utils.log import logging, set_verbosity
 from pisa.utils.numba_tools import myjit, WHERE
 from pisa.utils import vectorizer
 
 __all__ = [
     'histogram',
     'lookup',
-    'resample'
+    'resample',
 ]
 
 
 # --------- resampling ------------
+
 def resample(weights, old_sample, old_binning, new_sample, new_binning):
-    '''
-    resample binned data with a given binning into any
-    arbitrary `new_binning`
+    """Resample binned data with a given binning into any arbitrary
+    `new_binning`
 
     Paramters
     ---------
-
     weights : SmartArray
 
     old_sample : list of SmartArrays
@@ -45,7 +45,7 @@ def resample(weights, old_sample, old_binning, new_sample, new_binning):
 
     new_binning : PISA MultiDimBinning
 
-    '''
+    """
     # make sure thw two binning have the same dimensions!
     assert old_binning.names == new_binning.names, 'cannot translate betwen %s and %s'%(old_binning, new_binning)
 
@@ -70,20 +70,13 @@ def resample(weights, old_sample, old_binning, new_sample, new_binning):
     return lookup_flat_hist
 
 
-
 # --------- histogramming methods ---------------
 
-def histogram(sample, weights, binning, averaged):
-    return get_hist(sample, weights, binning, averaged)
-
-
 def get_hist(sample, weights, binning, averaged):
-    '''
-    histograming
+    """Histogram `sample` points, weighting by `weights`, according to `binning`.
 
     Paramters
     ---------
-
     sample : list of SmartArrays
 
     weights : SmartArray
@@ -91,15 +84,12 @@ def get_hist(sample, weights, binning, averaged):
     binning : PISA MultiDimBinning
 
     averaged : bool
-            if True, the histogram entries are averages of the numbers that
-            end up in a given bin. This for example must be used when oscillation
-            probabilities are translated.....otherwise we end up with probability*count
-            per bin
+        If True, the histogram entries are averages of the numbers that end up
+        in a given bin. This for example must be used when oscillation
+        probabilities are translated, otherwise we end up with
+        probability*count per bin
 
-    Notes
-    -----
-
-    '''
+    """
     if TARGET == 'cuda':
         flat_hist = get_hist_gpu(sample, weights, binning, apply_weights=True)
         if averaged:
@@ -113,6 +103,13 @@ def get_hist(sample, weights, binning, averaged):
         #print(flat_hist.get('host').shape)
         vectorizer.divide(flat_hist_counts, flat_hist)
     return flat_hist
+
+
+def histogram(sample, weights, binning, averaged):
+    return get_hist(sample, weights, binning, averaged)
+
+histogram.__doc__ = get_hist.__doc__
+
 
 def get_hist_gpu(sample, weights, binning, apply_weights=True):
     # ToDo:
@@ -131,50 +128,62 @@ def get_hist_gpu(sample, weights, binning, apply_weights=True):
         d_bin_edges_y = cuda.to_device(bin_edges[1])
         if binning.num_dims == 2:
             if arrays:
-                histogram_2d_kernel_arrays[(size+511)//512, 512](sample[0].get('gpu'),
-                                                                 sample[1].get('gpu'),
-                                                                 flat_hist,
-                                                                 d_bin_edges_x,
-                                                                 d_bin_edges_y,
-                                                                 weights.get('gpu'),
-                                                                 apply_weights)
+                histogram_2d_kernel_arrays[(size + 511) // 512, 512](
+                    sample[0].get('gpu'),
+                    sample[1].get('gpu'),
+                    flat_hist,
+                    d_bin_edges_x,
+                    d_bin_edges_y,
+                    weights.get('gpu'),
+                    apply_weights,
+                )
             else:
-                histogram_2d_kernel[(size+511)//512, 512](sample[0].get('gpu'),
-                                                          sample[1].get('gpu'),
-                                                          flat_hist,
-                                                          d_bin_edges_x,
-                                                          d_bin_edges_y,
-                                                          weights.get('gpu'),
-                                                          apply_weights)
+                histogram_2d_kernel[(size + 511) // 512, 512](
+                    sample[0].get('gpu'),
+                    sample[1].get('gpu'),
+                    flat_hist,
+                    d_bin_edges_x,
+                    d_bin_edges_y,
+                    weights.get('gpu'),
+                    apply_weights,
+                )
         elif binning.num_dims == 3:
             d_bin_edges_z = cuda.to_device(bin_edges[2])
             if arrays:
-                histogram_3d_kernel_arrays[(size+511)//512, 512](sample[0].get('gpu'),
-                                                                 sample[1].get('gpu'),
-                                                                 sample[2].get('gpu'),
-                                                                 flat_hist,
-                                                                 d_bin_edges_x,
-                                                                 d_bin_edges_y,
-                                                                 d_bin_edges_z,
-                                                                 weights.get('gpu'),
-                                                                 apply_weights)
+                histogram_3d_kernel_arrays[(size + 511) // 512, 512](
+                    sample[0].get('gpu'),
+                    sample[1].get('gpu'),
+                    sample[2].get('gpu'),
+                    flat_hist,
+                    d_bin_edges_x,
+                    d_bin_edges_y,
+                    d_bin_edges_z,
+                    weights.get('gpu'),
+                    apply_weights,
+                )
             else:
-                histogram_3d_kernel[(size+511)//512, 512](sample[0].get('gpu'),
-                                                          sample[1].get('gpu'),
-                                                          sample[2].get('gpu'),
-                                                          flat_hist,
-                                                          d_bin_edges_x,
-                                                          d_bin_edges_y,
-                                                          d_bin_edges_z,
-                                                          weights.get('gpu'),
-                                                          apply_weights)
+                histogram_3d_kernel[(size + 511) // 512, 512](
+                    sample[0].get('gpu'),
+                    sample[1].get('gpu'),
+                    sample[2].get('gpu'),
+                    flat_hist,
+                    d_bin_edges_x,
+                    d_bin_edges_y,
+                    d_bin_edges_z,
+                    weights.get('gpu'),
+                    apply_weights,
+                )
         return flat_hist
     else:
-        raise NotImplementedError('Other dimesnions that 2 and 3 on the GPU not supported right now')
+        raise NotImplementedError(
+            'Other dimesnions that 2 and 3 on the GPU not supported right now'
+        )
+
+get_hist_gpu.__doc__ = get_hist.__doc__
 
 
 def get_hist_np(sample, weights, binning, apply_weights=True):
-    '''helper function for numoy historams'''
+    """helper function for numoy historams"""
     bin_edges = [edges.magnitude for edges in binning.bin_edges]
     sample = [s.get('host') for s in sample]
     weights = weights.get('host')
@@ -191,6 +200,7 @@ def get_hist_np(sample, weights, binning, apply_weights=True):
         hist, _ = np.histogramdd(sample=sample, weights=w, bins=bin_edges)
         flat_hist = hist.ravel()
     return SmartArray(flat_hist.astype(FTYPE))
+
 
 # TODO: can we do just n-dimensional? And scalars or arbitrary array shapes? This is so ugly :/
 # Furthermore: optimize using shared memory
@@ -210,6 +220,7 @@ def histogram_2d_kernel(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y,
             else:
                 cuda.atomic.add(flat_hist, idx, 1.)
 
+
 @cuda.jit
 def histogram_2d_kernel_arrays(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y, weights, apply_weights):
     i = cuda.grid(1)
@@ -226,6 +237,7 @@ def histogram_2d_kernel_arrays(sample_x, sample_y, flat_hist, bin_edges_x, bin_e
                     cuda.atomic.add(flat_hist, (idx, j), weights[i, j])
                 else:
                     cuda.atomic.add(flat_hist, (idx, j), 1.)
+
 
 @cuda.jit
 def histogram_3d_kernel(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights, apply_weights):
@@ -245,6 +257,7 @@ def histogram_3d_kernel(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bi
                 cuda.atomic.add(flat_hist, idx, weights[i])
             else:
                 cuda.atomic.add(flat_hist, idx, 1.)
+
 
 @cuda.jit
 def histogram_3d_kernel_arrays(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights, apply_weights):
@@ -270,12 +283,10 @@ def histogram_3d_kernel_arrays(sample_x, sample_y, sample_z, flat_hist, bin_edge
 # ---------- Lookup methods ---------------
 
 def lookup(sample, flat_hist, binning):
-    '''
-    the inverse of histograming
+    """The inverse of histograming
 
     Paramters
     --------
-
     sample : list of SmartArrays
 
     flat_hist : SmartArray
@@ -285,7 +296,8 @@ def lookup(sample, flat_hist, binning):
     Notes
     -----
     this is only a 2d method right now
-    '''
+
+    """
     #print(binning)
     assert binning.num_dims in [2,3], 'can only do 2d and 3d at the moment'
     bin_edges = [edges.magnitude for edges in binning.bin_edges]
@@ -294,27 +306,60 @@ def lookup(sample, flat_hist, binning):
         #print 'looking up 1D'
         array = SmartArray(np.zeros_like(sample[0]))
         if binning.num_dims == 2:
-            lookup_vectorized_2d(sample[0].get(WHERE), sample[1].get(WHERE), flat_hist.get(WHERE), bin_edges[0], bin_edges[1], out=array.get(WHERE))
+            lookup_vectorized_2d(
+                sample[0].get(WHERE),
+                sample[1].get(WHERE),
+                flat_hist.get(WHERE),
+                bin_edges[0],
+                bin_edges[1],
+                out=array.get(WHERE),
+            )
         elif binning.num_dims == 3:
-            lookup_vectorized_3d(sample[0].get(WHERE), sample[1].get(WHERE), sample[2].get(WHERE), flat_hist.get(WHERE), bin_edges[0], bin_edges[1], bin_edges[2], out=array.get(WHERE))
+            lookup_vectorized_3d(
+                sample[0].get(WHERE),
+                sample[1].get(WHERE),
+                sample[2].get(WHERE),
+                flat_hist.get(WHERE),
+                bin_edges[0],
+                bin_edges[1],
+                bin_edges[2],
+                out=array.get(WHERE),
+            )
     elif flat_hist.ndim == 2:
         #print 'looking up ND'
         array = SmartArray(np.zeros((sample[0].size, flat_hist.shape[1]), dtype=FTYPE))
         if binning.num_dims == 2:
-            lookup_vectorized_2d_arrays(sample[0].get(WHERE), sample[1].get(WHERE), flat_hist.get(WHERE), bin_edges[0], bin_edges[1], out=array.get(WHERE))
+            lookup_vectorized_2d_arrays(
+                sample[0].get(WHERE),
+                sample[1].get(WHERE),
+                flat_hist.get(WHERE),
+                bin_edges[0],
+                bin_edges[1],
+                out=array.get(WHERE),
+            )
         elif binning.num_dims == 3:
-            lookup_vectorized_3d_arrays(sample[0].get(WHERE), sample[1].get(WHERE), sample[2].get(WHERE), flat_hist.get(WHERE), bin_edges[0], bin_edges[1], bin_edges[2], out=array.get(WHERE))
+            lookup_vectorized_3d_arrays(
+                sample[0].get(WHERE),
+                sample[1].get(WHERE),
+                sample[2].get(WHERE),
+                flat_hist.get(WHERE),
+                bin_edges[0],
+                bin_edges[1],
+                bin_edges[2],
+                out=array.get(WHERE),
+            )
     else:
         raise NotImplementedError()
     array.mark_changed(WHERE)
     return array
 
+
 @myjit
 def find_index(x, bin_edges):
-    ''' simple binary search
+    """simple binary search
 
-    direct trnasformations instead of search
-    '''
+    direct transformations instead of search
+    """
     # TODO: support lin and log binnings with
 
     first = 0
@@ -330,6 +375,7 @@ def find_index(x, bin_edges):
             last = i - 1
     return i
 
+
 if FTYPE == np.float32:
     _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:])']
 else:
@@ -337,9 +383,7 @@ else:
 
 @guvectorize(_SIGNATURE, '(),(),(j),(k),(l)->()', target=TARGET)
 def lookup_vectorized_2d(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y, weights):
-    '''
-    Vectorized gufunc to perform the lookup
-    '''
+    """Vectorized gufunc to perform the lookup"""
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
     if (sample_x_ >= bin_edges_x[0]
@@ -361,10 +405,9 @@ else:
 
 @guvectorize(_SIGNATURE, '(),(),(j,d),(k),(l)->(d)', target=TARGET)
 def lookup_vectorized_2d_arrays(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y, weights):
-    '''
-    Vectorized gufunc to perform the lookup
-    while flat hist and weights have both a second dimension
-    '''
+    """Vectorized gufunc to perform the lookup while flat hist and weights have
+    both a second dimension
+    """
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
     if (sample_x_ >= bin_edges_x[0]
@@ -380,6 +423,7 @@ def lookup_vectorized_2d_arrays(sample_x, sample_y, flat_hist, bin_edges_x, bin_
         for i in range(weights.size):
             weights[i] = 0.
 
+
 if FTYPE == np.float32:
     _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], f4[:])']
 else:
@@ -387,9 +431,7 @@ else:
 
 @guvectorize(_SIGNATURE, '(),(),(),(j),(k),(l),(m)->()', target=TARGET)
 def lookup_vectorized_3d(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights):
-    '''
-    Vectorized gufunc to perform the lookup
-    '''
+    """Vectorized gufunc to perform the lookup"""
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
     sample_z_ = sample_z[0]
@@ -415,10 +457,8 @@ else:
 
 @guvectorize(_SIGNATURE, '(),(),(),(j,d),(k),(l),(m)->(d)', target=TARGET)
 def lookup_vectorized_3d_arrays(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights):
-    '''
-    Vectorized gufunc to perform the lookup
-    while flat hist and weights have both a second dimension
-    '''
+    """Vectorized gufunc to perform the lookup while flat hist and weights have
+    both a second dimension"""
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
     sample_z_ = sample_z[0]
@@ -438,30 +478,34 @@ def lookup_vectorized_3d_arrays(sample_x, sample_y, sample_z, flat_hist, bin_edg
         for i in range(weights.size):
             weights[i] = 0.
 
+
 def test_histogram():
+    """Unit tests for `histogram` function"""
     n_evts = 100
     x = np.arange(n_evts, dtype=FTYPE)
     y = np.arange(n_evts, dtype=FTYPE)
     w = np.ones(n_evts, dtype=FTYPE)
-    #w *= np.random.rand(n_evts)
 
     x = SmartArray(x)
     y = SmartArray(y)
     w = SmartArray(w)
 
-
     binning_x = OneDimBinning(name='x', num_bins=10, is_lin=True, domain=[0, 100])
     binning_y = OneDimBinning(name='y', num_bins=10, is_lin=True, domain=[0, 100])
     binning = MultiDimBinning([binning_x, binning_y])
 
-    sample = [x, y]
-    weights = w
-    averaged = True
+    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=False)
+    assert np.array_equal(
+        histo.reshape(10, 10),
+        np.diag(np.full(shape=10, fill_value=10))
+    )
 
-    histo = histogram(sample, weights, binning, averaged)
+    histo = histogram(sample=[x, y], weights=w, binning=binning, averaged=True)
+    assert np.array_equal(histo.reshape(10, 10), np.diag(np.ones(10)))
 
-    assert np.array_equal(histo.reshape(10, 10), np.zeros(shape=(10, 10)))
+    logging.info('<< PASS : test_histogram >>')
 
 
 if __name__ == '__main__':
+    set_verbosity(1)
     test_histogram()

--- a/pisa/utils/cache.py
+++ b/pisa/utils/cache.py
@@ -209,7 +209,7 @@ class DiskCache(object):
     >>> disk_cache[13] = x
     >>> disk_cache[14] = x
     >>> y = disk_cache[12]
-    >>> print y == x
+    >>> print(y == x)
     True
     >>> len(disk_cache)
     3

--- a/pisa/utils/comparisons.py
+++ b/pisa/utils/comparisons.py
@@ -219,10 +219,22 @@ def recursiveEquality(x, y):
             logging.trace('shape(x): %s' %np.shape(x))
             logging.trace('shape(y): %s' %np.shape(y))
             return False
-        if not np.allclose(x, y, **ALLCLOSE_KW):
-            logging.trace('x: %s' %x)
-            logging.trace('y: %s' %y)
-            return False
+
+        if isinstance(x, NP_TYPES):
+            dtype = x.dtype.type
+        else:
+            dtype = y.dtype.type
+
+        if issubclass(dtype, np.floating):
+            if not np.allclose(x, y, **ALLCLOSE_KW):
+                logging.trace('x: %s' %x)
+                logging.trace('y: %s' %y)
+                return False
+        else:
+            if not np.all(x == y):
+                logging.trace('x: %s' %x)
+                logging.trace('y: %s' %y)
+                return False
 
     # dict
     elif isinstance(x, Mapping):

--- a/pisa/utils/comparisons.py
+++ b/pisa/utils/comparisons.py
@@ -675,6 +675,8 @@ def interpret_quantity(value, expect_sequence):
         else:
             if isbarenumeric(value):
                 value = value * ureg.dimensionless
+            elif isinstance(value, ureg.Quantity):
+                pass
             else:
                 value = ureg.Quantity.from_tuple(value)
     else:

--- a/pisa/utils/config_parser.py
+++ b/pisa/utils/config_parser.py
@@ -270,22 +270,22 @@ def parse_quantity(string):
     Examples
     --------
     >>> quant = parse_quantity('1.2 +/- 0.7 * units.meter')
-    >>> print str(quant)
+    >>> print(str(quant))
     1.2+/-0.7 meter
-    >>> print '{:~}'.format(quant)
+    >>> print('{:~}'.format(quant))
     1.2+/-0.7 m
-    >>> print quant.magnitude
+    >>> print(quant.magnitude)
     1.2+/-0.7
-    >>> print quant.units
+    >>> print(quant.units)
     meter
-    >>> print quant.nominal_value
+    >>> print(quant.nominal_value)
     1.2
-    >>> print quant.std_dev
+    >>> print(quant.std_dev)
     0.7
 
     Also note that spaces and the "*" are optional:
 
-    >>> print parse_quantity('1+/-1units.GeV')
+    >>> print(parse_quantity('1+/-1units.GeV'))
     1.0+/-1.0 gigaelectron_volt
 
     """
@@ -319,16 +319,16 @@ def parse_string_literal(string):
 
     Examples
     --------
-    >>> print parse_string_literal('true')
+    >>> print(parse_string_literal('true'))
     True
 
-    >>> print parse_string_literal('False')
+    >>> print(parse_string_literal('False'))
     False
 
-    >>> print parse_string_literal('none')
+    >>> print(parse_string_literal('none'))
     None
 
-    >>> print parse_string_literal('something else')
+    >>> print(parse_string_literal('something else'))
     'something else'
 
     """
@@ -357,7 +357,7 @@ def interpret_param_subfields(subfields, selector=None, pname=None, attr=None):
 
     Examples
     --------
-    >>> print interpret_param_subfields(subfields=['nh', 'deltam31', 'range'])
+    >>> print(interpret_param_subfields(subfields=['nh', 'deltam31', 'range']))
     {'pname': 'deltam31', 'subfields': [], 'attr': ['range'], 'selector': 'nh'}
 
     """

--- a/pisa/utils/fileio.py
+++ b/pisa/utils/fileio.py
@@ -198,7 +198,7 @@ def get_valid_filename(s):
 
     Examples
     --------
-    >>> print get_valid_filename(r'A,bCd $%#^#*!()"\' .ext ')
+    >>> print(get_valid_filename(r'A,bCd $%#^#*!()"\' .ext '))
     'a_bcd__.ext'
 
     """

--- a/pisa/utils/fileio.py
+++ b/pisa/utils/fileio.py
@@ -455,7 +455,7 @@ def from_file(fname, fmt=None, **kwargs):
 
     Returns
     -------
-    Object instantiated from the file (string, dictionariy, ...). Each format
+    Object instantiated from the file (string, dictionary, ...). Each format
     is interpreted differently.
 
     Raises

--- a/pisa/utils/flavInt.py
+++ b/pisa/utils/flavInt.py
@@ -100,12 +100,12 @@ class BarSep(object):
     Examples
     --------
     >>> nuebar = NuFlav('nuebar')
-    >>> print str(nuebar)
+    >>> print(str(nuebar))
     nuebar
     >>> with BarSep('_'):
-    ...     print nuebar
+    ...     print(nuebar)
     nue_bar
-    >>> print str(nuebar)
+    >>> print(str(nuebar))
     nuebar
 
     """
@@ -1754,8 +1754,8 @@ class CombinedFlavIntData(FlavIntData):
                 groupings_found.append(nfig)
 
             named_g, named_ung = xlateGroupsStr(','.join(val.keys()))
-            #print 'named_g:', named_g
-            #print 'named_ung:', named_ung
+            #print('named_g:', named_g)
+            #print('named_ung:', named_ung)
             # Force keys to standard naming convention (be liberal on input,
             # strict on output)
             for key in val.keys():
@@ -1896,24 +1896,24 @@ class CombinedFlavIntData(FlavIntData):
         """
         #with BarSep('_'):
         all_keys = list(args)
-        #print 'all_keys:', all_keys
+        #print('all_keys:', all_keys)
         tgt_grp = NuFlavIntGroup(all_keys[0])
-        #print 'tgt_grp0:', tgt_grp
-        #print 'flavints_to_keys:', self.flavints_to_keys
+        #print('tgt_grp0:', tgt_grp)
+        #print('flavints_to_keys:', self.flavints_to_keys)
         for (flavints, key) in self.flavints_to_keys:
-            #print 'flavints:', flavints, 'type:', type(flavints)
-            #print 'key:', key, 'type:', type(key)
+            #print('flavints:', flavints, 'type:', type(flavints))
+            #print('key:', key, 'type:', type(key))
             match = False
             # Identical
             if tgt_grp == flavints:
                 all_keys[0] = key
                 match = True
-                #print 'found exact match:', tgt_grp, '==', flavints
+                #print('found exact match:', tgt_grp, '==', flavints)
             # Requested flavints are strict subset
             elif not tgt_grp - flavints:
                 all_keys[0] = key
                 match = True
-                #print 'found subset match:', tgt_grp, 'in', flavints
+                #print('found subset match:', tgt_grp, 'in', flavints)
                 logging.debug('Requesting data for subset (%s) of'
                               ' grouping %s', str(tgt_grp), str(flavints))
             # Get it
@@ -1923,7 +1923,7 @@ class CombinedFlavIntData(FlavIntData):
                 lvl = self
                 for k in branch_keys:
                     lvl = dict.__getitem__(lvl, k)
-                #print 'node_key:', node_key, 'type:', type(node_key)
+                #print('node_key:', node_key, 'type:', type(node_key))
                 return deepcopy(dict.__getitem__(lvl, node_key))
         # If you get this far, no match was found
         raise ValueError('Could not locate data for group %s' % str(tgt_grp))

--- a/pisa/utils/flavor_interaction_types.md
+++ b/pisa/utils/flavor_interaction_types.md
@@ -49,11 +49,11 @@ nkg.cc_flavints # -> (numu_cc,)
 
 # Loop over all particle CC flavInts
 for fi in flavInt.NuFlavIntGroup('nuallcc'):
-    print fi
+    print(fi)
 
 # String, TeX
 nkg = flavInt.NuFlavIntGroup('nuallcc')
-print nkg # -> 'nuall_cc'
+print(nkg) # -> 'nuall_cc'
 nkg.tex # -> r'{\nu_{\rm all}} \, {\rm CC}'
 
 ```
@@ -126,12 +126,12 @@ fidat2 = flavInt.FlavIntData('data.json')
 # Comparisons: intelligently recurses through the
 # structure and any nested sub-structures
 # (lists, dicts) when "==" is used
-print fidat == fidat2 # -> True
+print(fidat == fidat2) # -> True
 
 # There is a function for doing this in `pisa.utils.comparisons` that works
 # with (almost) any nested object, including FlavIntData objects::
 from pisa.utils.comparisons import recursiveEquality
-print recursiveEquality(fidat, fidat2) # -> True
+print(recursiveEquality(fidat, fidat2)) # -> True
 ```
 
 ## Examples of using Events container object
@@ -141,7 +141,7 @@ from pisa.core.events import Events
 
 ev = Events('events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e2evts_set0__unjoined__with_fluxes_honda-2015-spl-solmin-aa.hdf5')
 
-print ev.metadata
+print(ev.metadata)
 ```
 Result:
 ```python

--- a/pisa/utils/hdf.py
+++ b/pisa/utils/hdf.py
@@ -9,6 +9,7 @@ import os
 
 import numpy as np
 import h5py
+from six import string_types
 
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.hash import hash_obj
@@ -164,22 +165,25 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
 
     def store_recursively(fhandle, node, path=None, attrs=None,
                           node_hashes=None):
-        """Function for interatively doing the work"""
+        """Function for iteratively doing the work"""
         path = [] if path is None else path
-        node_hashes = OrderedDict() if node_hashes is None else node_hashes
         full_path = '/' + '/'.join(path)
-        if attrs is not None:
+        node_hashes = OrderedDict() if node_hashes is None else node_hashes
+
+        if attrs is None:
+            sorted_attr_keys = []
+        else:
             if isinstance(attrs, OrderedDict):
                 sorted_attr_keys = attrs.keys()
             else:
                 sorted_attr_keys = sorted(attrs.keys())
+
         if isinstance(node, Mapping):
             logging.trace('  creating Group "%s"', full_path)
             try:
                 dset = fhandle.create_group(full_path)
-                if attrs is not None:
-                    for key in sorted_attr_keys:
-                        dset.attrs[key] = attrs[key]
+                for key in sorted_attr_keys:
+                    dset.attrs[key] = attrs[key]
             except ValueError:
                 pass
 
@@ -205,6 +209,7 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
                 # Hardlink the matching existing dataset
                 fhandle[full_path] = fhandle[node_hashes[node_hash]]
                 return
+
             # For now, convert None to np.nan since h5py appears to not handle
             # None
             if node is None:
@@ -213,6 +218,7 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
                     '  encountered `None` at node "%s"; converting to'
                     ' np.nan', full_path
                 )
+
             # "Scalar datasets don't support chunk/filter options". Shuffling
             # is a good idea otherwise since subsequent compression will
             # generally benefit; shuffling requires chunking. Compression is
@@ -227,19 +233,35 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
                 # Store the node_hash for linking to later if this is more than
                 # a scalar datatype. Assumed that "None" has
                 node_hashes[node_hash] = full_path
-            if isinstance(node, str):
-                # TODO: Treat strings as follows? Would this break
-                # compatibility with pytables/Pandas? What are benefits?
-                # Leaving the following two lines out for now...
 
-                #dtype = h5py.special_dtype(vlen=str)
-                #fh.create_dataset(k,data=v,dtype=dtype)
+            # -- Handle special types -- #
 
-                # ... Instead: creating length-1 array out of string; this
-                # seems to be compatible with both h5py and pytables
-                node = np.array(node)
+            # See h5py docs at
+            #
+            #   https://docs.h5py.org/en/stable/strings.html#how-to-store-text-strings
+            #
+            # where using `bytes` objects (i.e., in numpy, np.string_) is
+            # deemed the most compatible way to encode objects, but apparently
+            # we don't have pytables compatibility right now.
+            #
+            # For boolean support, see
+            #
+            #   https://docs.h5py.org/en/stable/faq.html#faq
 
-            logging.trace('  creating dataset at node "%s", hash %s',
+            # TODO: make written hdf5 files compatible with pytables
+            # see docs at https://www.pytables.org/usersguide/datatypes.html
+
+            if isinstance(node, string_types):
+                node = np.string_(node)
+            elif isinstance(node, bool):  # includes np.bool
+                node = np.bool_(node)  # same as np.bool8
+            elif isinstance(node, np.ndarray):
+                if issubclass(node.dtype.type, string_types):
+                    node = node.astype(np.string_)
+                elif node.dtype.type in (bool, np.bool):
+                    node = node.astype(np.bool_)
+
+            logging.trace('  creating dataset at path "%s", hash %s',
                           full_path, node_hash)
             try:
                 dset = fhandle.create_dataset(
@@ -255,15 +277,14 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
                         compression=None, shuffle=shuffle, fletcher32=False
                     )
                 except:
-                    logging.error('  full_path: %s', full_path)
+                    logging.error('  full_path: "%s"', full_path)
                     logging.error('  chunks   : %s', str(chunks))
                     logging.error('  shuffle  : %s', str(shuffle))
-                    logging.error('  node     : %s', str(node))
+                    logging.error('  node     : "%s"', str(node))
                     raise
 
-            if attrs is not None:
-                for key in sorted_attr_keys:
-                    dset.attrs[key] = attrs[key]
+            for key in sorted_attr_keys:
+                dset.attrs[key] = attrs[key]
 
     # Perform the actual operation using the dict passed in by user
     if isinstance(tgt, str):
@@ -292,31 +313,45 @@ def test_hdf():
     data = OrderedDict([
         ('top', OrderedDict([
             ('secondlvl1', OrderedDict([
-                ('thirdlvl11', np.linspace(1, 100, 10000)),
-                ('thirdlvl12', "this is a string")
+                ('thirdlvl11', np.linspace(1, 100, 10000).astype(np.float64)),
+                ('thirdlvl12', b"this is a string"),
+                ('thirdlvl13', b"this is another string"),
+                ('thirdlvl14', 1),
+                ('thirdlvl15', 1.1),
+                ('thirdlvl16', np.float32(1.1)),
+                ('thirdlvl17', np.float64(1.1)),
+                ('thirdlvl18', np.int8(1)),
+                ('thirdlvl19', np.int16(1)),
+                ('thirdlvl110', np.int32(1)),
+                ('thirdlvl111', np.int64(1)),
+                ('thirdlvl112', np.uint8(1)),
+                ('thirdlvl113', np.uint16(1)),
+                ('thirdlvl114', np.uint32(1)),
+                ('thirdlvl115', np.uint64(1)),
             ])),
             ('secondlvl2', OrderedDict([
-                ('thirdlvl21', np.linspace(1, 100, 10000)),
-                ('thirdlvl22', "this is a string")
+                ('thirdlvl21', np.linspace(1, 100, 10000).astype(np.float32)),
+                ('thirdlvl22', b"this is a string"),
+                ('thirdlvl23', b"this is another string"),
             ])),
             ('secondlvl3', OrderedDict([
-                ('thirdlvl31', np.linspace(1, 100, 10000)),
-                ('thirdlvl32', "this is a string")
+                ('thirdlvl31', np.array(range(1000)).astype(np.int)),
+                ('thirdlvl32', b"this is a string"),
             ])),
             ('secondlvl4', OrderedDict([
                 ('thirdlvl41', np.linspace(1, 100, 10000)),
-                ('thirdlvl42', "this is a string")
+                ('thirdlvl42', b"this is a string"),
             ])),
             ('secondlvl5', OrderedDict([
                 ('thirdlvl51', np.linspace(1, 100, 10000)),
-                ('thirdlvl52', "this is a string")
+                ('thirdlvl52', b"this is a string"),
             ])),
             ('secondlvl6', OrderedDict([
                 ('thirdlvl61', np.linspace(100, 1000, 10000)),
-                ('thirdlvl62', "this is a string")
+                ('thirdlvl62', b"this is a string"),
             ])),
         ]))
-    ]) # yapf: disable
+    ])
 
     temp_dir = mkdtemp()
     try:
@@ -324,15 +359,57 @@ def test_hdf():
         to_hdf(data, fpath, overwrite=True, warn=False)
         loaded_data1 = from_hdf(fpath)
         assert data.keys() == loaded_data1.keys()
-        assert recursiveEquality(data, loaded_data1)
+        assert recursiveEquality(data, loaded_data1), \
+                str(data) + "\n" + str(loaded_data1)
 
         attrs = OrderedDict([
-            ('float1', 9.98237),
-            ('float2', 1.),
-            ('pi', np.pi),
+            ('float', 9.98237),
+            ('float32', np.float32(1.)),
+            ('float64', np.float64(1.)),
+            ('pi', np.float64(np.pi)),
+
             ('string', "string attribute!"),
-            ('int', 1)
-        ]) # yapf: disable
+
+            ('int', 1),
+            ('int8', np.int8(1)),
+            ('int16', np.int16(1)),
+            ('int32', np.int32(1)),
+            ('int64', np.int64(1)),
+
+            ('uint8', np.uint8(1)),
+            ('uint16', np.uint16(1)),
+            ('uint32', np.uint32(1)),
+            ('uint64', np.uint64(1)),
+
+            ('bool', True),
+            ('bool8', np.bool8(True)),
+            ('bool_', np.bool_(True)),
+        ])
+
+        attr_type_checkers = {
+            "float": lambda x: isinstance(x, float),
+            "float32": lambda x: x.dtype == np.float32,
+            "float64": lambda x: x.dtype == np.float64,
+            "pi": lambda x: x.dtype == np.float64,
+
+            "string": lambda x: isinstance(x, string_types),
+
+            "int": lambda x: isinstance(x, int),
+            "int8": lambda x: x.dtype == np.int8,
+            "int16": lambda x: x.dtype == np.int16,
+            "int32": lambda x: x.dtype == np.int32,
+            "int64": lambda x: x.dtype == np.int64,
+
+            "uint8": lambda x: x.dtype == np.uint8,
+            "uint16": lambda x: x.dtype == np.uint16,
+            "uint32": lambda x: x.dtype == np.uint32,
+            "uint64": lambda x: x.dtype == np.uint64,
+
+            "bool": lambda x: isinstance(x, bool),
+            "bool8": lambda x: x.dtype == np.bool8,
+            "bool_": lambda x: x.dtype == np.bool_,
+        }
+
         fpath = os.path.join(temp_dir, 'to_hdf_withattrs.hdf5')
         to_hdf(data, fpath, attrs=attrs, overwrite=True, warn=False)
         loaded_data2, loaded_attrs = from_hdf(fpath, return_attrs=True)
@@ -342,11 +419,11 @@ def test_hdf():
         assert recursiveEquality(data, loaded_data2)
         assert recursiveEquality(attrs, loaded_attrs)
 
-        for k, v in attrs.items():
-            tgt_type = type(attrs[k])
-            assert isinstance(loaded_attrs[k], tgt_type), \
-                    "key %s: val '%s' is type '%s' but should be '%s'" % \
-                    (k, v, type(loaded_attrs[k]), tgt_type)
+        for key, val in attrs.items():
+            tgt_type_checker = attr_type_checkers[key]
+            assert tgt_type_checker(val), \
+                    "key '%s': val '%s' is type '%s'" % \
+                    (key, val, type(loaded_attrs[key]))
     finally:
         rmtree(temp_dir)
 

--- a/pisa/utils/jsons.py
+++ b/pisa/utils/jsons.py
@@ -131,7 +131,7 @@ def from_json(filename, cls=None):
                 )
             )
         if hasattr(cls, "from_json"):
-            return cls.from_json(from_json(filename=filename))
+            return cls.from_json(filename)
 
         # Otherwise, handle instantiating the class generically (which WILL
         # surely fail for many types) based on the type of the object loaded

--- a/pisa/utils/jsons.py
+++ b/pisa/utils/jsons.py
@@ -281,9 +281,6 @@ class NumpyEncoder(json.JSONEncoder):
         if hasattr(obj, 'serializable_state'):
             return obj.serializable_state
 
-        if not isinstance(obj, string_types) and isinstance(obj, Iterable):
-            return [self.default(x) for x in obj]
-
         # TODO: poor form to have a way to get this into a JSON file but no way
         # to get it out of a JSON file... so either write a deserializer, or
         # remove this and leave it to other objects to do the following.
@@ -291,6 +288,9 @@ class NumpyEncoder(json.JSONEncoder):
             if obj.dimensionless:
                 return self.default(obj.magnitude)
             return [self.default(x) for x in obj.to_tuple()]
+
+        if not isinstance(obj, string_types) and isinstance(obj, Iterable):
+            return [self.default(x) for x in obj]
 
         if isinstance(obj, np.integer):
             return int(obj)

--- a/pisa/utils/llh_server.py
+++ b/pisa/utils/llh_server.py
@@ -45,7 +45,7 @@ __all__ = [
 from argparse import ArgumentParser
 from multiprocessing import cpu_count, Process
 import pickle
-import SocketServer
+import socketserver
 import struct
 
 from pisa.core.distribution_maker import DistributionMaker
@@ -59,7 +59,6 @@ DFLT_NUM_SERVERS = cpu_count()
 
 class ConnectionClosed(Exception):
     """Connection closed"""
-    pass
 
 
 def send_obj(obj, sock):
@@ -137,14 +136,14 @@ def serve(config, ref, port=DFLT_PORT):
     ref = MapSet.from_json(ref)
 
     # Define server as a closure such that it captures the above-instantiated objects
-    class MyTCPHandler(SocketServer.BaseRequestHandler):
+    class MyTCPHandler(socketserver.BaseRequestHandler):
         """
         The request handler class for our server.
 
         It is instantiated once per connection to the server, and must override
         the handle() method to implement communication to the client.
 
-        See SocketServer.BaseRequestHandler for documentation of args.
+        See socketserver.BaseRequestHandler for documentation of args.
         """
         def handle(self):
             try:
@@ -159,7 +158,7 @@ def serve(config, ref, port=DFLT_PORT):
             )
             send_obj(llh, self.request)
 
-    server = SocketServer.TCPServer((DFLT_HOST, int(port)), MyTCPHandler)
+    server = socketserver.TCPServer((DFLT_HOST, int(port)), MyTCPHandler)
     print("llh server started on {}:{}".format(DFLT_HOST, port))
     server.serve_forever()
 
@@ -197,11 +196,15 @@ def main(description=__doc__):
     parser = ArgumentParser(description=description)
     parser.add_argument(
         "--config",
+        required=True,
         nargs="+",
-        help="""Resource location of a pipeline config; repeat --config for
-        multiple pipelines"""
+        help="""Resource location of one or more pipeline configs""",
     )
-    parser.add_argument("--ref", help="Resource location of reference (truth) map")
+    parser.add_argument(
+        "--ref",
+        required=True,
+        help="Resource location of reference (truth) map",
+    )
     parser.add_argument("--port", default=DFLT_PORT)
     parser.add_argument(
         "--num",

--- a/pisa/utils/parallel.py
+++ b/pisa/utils/parallel.py
@@ -131,7 +131,7 @@ def parallel_run(func, kind, num_parallel, scalar_func, divided_args_mask,
                          % (len(divided_args_mask), len(args)))
 
     if divided_kwargs_names:
-        diff = set(divided_kwargs_names).difference(kwargs.keys())
+        diff = set(divided_kwargs_names).difference(set(kwargs.keys()))
         if len(diff) > 0:
             raise ValueError('Excess names in `divided_kwargs_names`: %s'
                              % ', '.join(['"%s"' % s for s in sorted(diff)]))
@@ -149,7 +149,7 @@ def parallel_run(func, kind, num_parallel, scalar_func, divided_args_mask,
     else:
         pkwarg_lengths = {}
 
-    unique_lengths = set(parg_lengths + pkwarg_lengths.values())
+    unique_lengths = set(parg_lengths + list(pkwarg_lengths.values()))
     if len(unique_lengths) != 1:
         for length in sorted(unique_lengths):
             parglist = []

--- a/pisa/utils/vbwkde.py
+++ b/pisa/utils/vbwkde.py
@@ -288,6 +288,14 @@ def vbwkde(data, weights=None, n_dct=None, min=None, max=None, n_addl_iter=0,
     assert n_addl_iter >= 0 and int(n_addl_iter) == n_addl_iter
     n_addl_iter = int(n_addl_iter)
 
+    # Parameters to set up the points on which to evaluate the density
+    if min is None or max is None:
+        minimum = data.min()
+        maximum = data.max()
+        data_range = maximum - minimum
+        min = minimum - data_range/2 if min is None else min
+        max = maximum + data_range/2 if max is None else max
+
     # Pilot density estimate for the VBW KDE comes from fixed bandwidth KDE
     # using the Improved Sheather-Jones algorithm. By specifying
     # `evaluate_at` to be None, `fbwkde` derives a regular grid at which to

--- a/pisa_examples/resources/settings/pipeline/example.cfg
+++ b/pisa_examples/resources/settings/pipeline/example.cfg
@@ -11,7 +11,7 @@
 
 [pipeline]
 
-# Define order of stages to be excecuted one after another, and specify the
+# Define order of stages to be executed one after another, and specify the
 # service to use for each of them as stage1:serviceA, stage2:serviceB, ...
 order = data.simple_data_loader, flux.pi_simple, osc.pi_prob3, aeff.pi_aeff, utils.pi_hist
 
@@ -30,15 +30,15 @@ param_selections = nh
 
 [data.simple_data_loader]
 
-# 'specs' tell the stages what format the data should be in, normally events or 
+# 'specs' tell the stages what format the data should be in, normally events or
 # histograms (which are specified via a binning definition). PISA pi is designed
 # such that stages should be able to accept either binned or event-wise data and
 # perform either binned or event-wise calculations, although some stages may
 # only support specific configurations.
 # The particular options to each stage are:
 #   1) input_specs  : the format the stage expects the input data to be in
-#   2) calc_specs   : rarely used, but can specify a particular different format for the calculation 
-#                     to be performed in (for example compute oscillation probabilities on a grid and 
+#   2) calc_specs   : rarely used, but can specify a particular different format for the calculation
+#                     to be performed in (for example compute oscillation probabilities on a grid and
 #                     look them up for event-wise calculation)
 #   3) output_specs : the format the stage should output data in
 
@@ -47,7 +47,7 @@ calc_specs = None
 output_specs = events
 
 # Define the categories of events to be produced by this pipeline
-# Here we use distinct categories for each flavor, particle vs antiparticle, 
+# Here we use distinct categories for each flavor, particle vs antiparticle,
 # and CC vs NC interaction
 output_names = nue_cc, numu_cc, nutau_cc, nuebar_cc, numubar_cc, nutaubar_cc, nue_nc, numu_nc, nutau_nc, nuebar_nc, numubar_nc, nutaubar_nc
 
@@ -55,24 +55,26 @@ output_names = nue_cc, numu_cc, nutau_cc, nuebar_cc, numubar_cc, nutaubar_cc, nu
 events_file = events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e2evts_set0__unjoined__with_fluxes_honda-2015-spl-solmin-aa.hdf5
 
 # Any cuts that should be applied to the events
-mc_cuts = (pid>=-3)
+mc_cuts = (pid >= -3)
 
 # Map input file variables to PISA event variables
-data_dict = {'true_energy':'true_energy', \
-            'true_coszen':'true_coszen', \
-            'reco_energy':'reco_energy', \
-            'reco_coszen':'reco_coszen', \
-            'pid':'pid', \
-            'weighted_aeff':'weighted_aeff',\
-            'nominal_nu_flux':['nominal_nue_flux', 'nominal_numu_flux'], \
-            'nominal_nubar_flux':['nominal_nuebar_flux', 'nominal_numubar_flux']}
+data_dict = {
+    'true_energy': 'true_energy',
+    'true_coszen': 'true_coszen',
+    'reco_energy': 'reco_energy',
+    'reco_coszen': 'reco_coszen',
+    'pid': 'pid',
+    'weighted_aeff': 'weighted_aeff',
+    'nominal_nu_flux': ['nominal_nue_flux', 'nominal_numu_flux'],
+    'nominal_nubar_flux': ['nominal_nuebar_flux', 'nominal_numubar_flux']
+    }
 
 
 #------------------------------------------------------------------------------
 # 'flux' stage parameters
 #------------------------------------------------------------------------------
 
-# This stage computes weight modifications for events according 
+# This stage computes weight modifications for events according
 # to the flux systematics.
 # Right now the implementation is a parameterisation of the
 # Barr 2006 paper, plus handling for the spectral index.
@@ -122,7 +124,7 @@ param.delta_index.range = nominal + [-5, +5] * sigma
 
 [osc.pi_prob3]
 
-# Here our input and output will be events, but we perform the ocillation 
+# Here our input and output will be events, but we perform the oscillation
 # probability calculation on a grid for speed
 input_specs = events
 calc_specs = calc_grid
@@ -192,7 +194,7 @@ param.ih.deltam31.range = [-0.007, -0.001] * units.eV**2
 # 'effective area' stage parameters
 #------------------------------------------------------------------------------
 
-# This stage is responsible for handling a host of normalisations of the 
+# This stage is responsible for handling a host of normalisations of the
 # events/histograms (the stage name is a bit misleading)
 # We provide the livetime for our data (or template which matches it)
 # The parameter aeff_scale is the overall normalisation for all events,
@@ -243,11 +245,10 @@ input_specs = events
 # Here we define the binning we will use for our output histogram
 # This is the same binning as would be used for real data, and hence must only
 # use reconstructed variables (no truth information).
-# The binning definitions can be found in a  separate 'example_binning.cfg' file, 
+# The binning definitions can be found in a  separate 'example_binning.cfg' file,
 # which is imported by the first line of this file.
 output_specs = reco_binning
 
 # Specify if and how to assign uncertainties to the output maps,
 # here sum of weights-squared
 error_method = sumw2
-

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -18,6 +18,7 @@
 #  limitations under the License
 #
 
+export PISA_RESOURCES=/home/justin/src/fridge/analysis/common
 
 BASEDIR=$(dirname "$0")
 PISA=$BASEDIR/..
@@ -88,12 +89,12 @@ done
 
 OUTDIR_CPU64_NH_PIPELINE=$TMP/cpu64nh_pipeline
 echo "=============================================================================="
-echo "Running pipeline.py with example_cake.cfg, with CPU & fp64 selected."
+echo "Running pipeline.py with example.cfg, with CPU & fp64 selected."
 echo "Storing results to"
 echo "  $OUTDIR_CPU64_NH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
-	-p settings/pipeline/example_cake.cfg \
+	-p settings/pipeline/example.cfg \
 	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "nh" \
@@ -102,12 +103,12 @@ PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
 
 OUTDIR_CPU32_NH_PIPELINE=$TMP/cpu32nh_pipeline
 echo "=============================================================================="
-echo "Running pipeline.py with example_cake.cfg, with CPU & fp32 selected."
+echo "Running pipeline.py with example.cfg, with CPU & fp32 selected."
 echo "Storing results to"
 echo "  $OUTDIR_CPU32_NH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float32 python $PISA/pisa/core/pipeline.py \
-	-p settings/pipeline/example_cake.cfg \
+	-p settings/pipeline/example.cfg \
 	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "nh" \
@@ -191,12 +192,12 @@ PISA_FTYPE=float64 python $PISA/pisa/scripts/compare.py \
 
 OUTDIR_CPU64_IH_PIPELINE=$TMP/cpu64ih_pipeline
 echo "=============================================================================="
-echo "Running pipeline.py with example_cake.cfg, with ih selected."
+echo "Running pipeline.py with example.cfg, with ih selected."
 echo "Storing results to"
 echo "  $OUTDIR_CPU64_IH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
-	-p settings/pipeline/example_cake.cfg \
+	-p settings/pipeline/example.cfg \
 	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "ih" \
@@ -225,12 +226,12 @@ python $PISA/pisa/scripts/compare.py \
 # TODO: removed since -a option doesn't work for distmaker
 #OUTDIR_CPU64_NH_DISTMAKER=$TMP/cpu64nh_distmaker
 #echo "=============================================================================="
-#echo "Running distribution_maker.py with example_cake.cfg, with nh selected."
+#echo "Running distribution_maker.py with example.cfg, with nh selected."
 #echo "Storing results to"
 #echo "  $OUTDIR_CPU64_NH_DISTMAKER"
 #echo "=============================================================================="
 #PISA_FTYPE=float64 python $PISA/pisa/core/distribution_maker.py \
-#	-p settings/pipeline/example_cake.cfg \
+#	-p settings/pipeline/example.cfg \
 #	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 #	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 #	--select "nh" \

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -18,12 +18,11 @@
 #  limitations under the License
 #
 
-export PISA_RESOURCES=/home/justin/src/fridge/analysis/common
 
 BASEDIR=$(dirname "$0")
 PISA=$BASEDIR/..
 TMP=/tmp/pisa_tests
-export PISA_RESOURCES=${TMP}/pisa_resources
+export PISA_RESOURCES=${TMP}/pisa_resources:/home/justin/src/fridge/analysis/common
 mkdir -p $TMP
 mkdir -p $PISA_RESOURCES
 echo "PISA=$PISA"

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -22,7 +22,7 @@
 BASEDIR=$(dirname "$0")
 PISA=$BASEDIR/..
 TMP=/tmp/pisa_tests
-export PISA_RESOURCES=${TMP}/pisa_resources:/home/justin/src/fridge/analysis/common
+export PISA_RESOURCES=${TMP}/pisa_resources:$PISA_RESOURCES
 mkdir -p $TMP
 mkdir -p $PISA_RESOURCES
 echo "PISA=$PISA"
@@ -94,8 +94,6 @@ echo "  $OUTDIR_CPU64_NH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
 	-p settings/pipeline/example.cfg \
-	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
-	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "nh" \
 	--outdir $OUTDIR_CPU64_NH_PIPELINE \
 	--png -v
@@ -116,12 +114,12 @@ PISA_FTYPE=float32 python $PISA/pisa/core/pipeline.py \
 
 OUTDIR_GPU64_NH_PIPELINE=$TMP/gpu64nh_pipeline
 echo "=============================================================================="
-echo "Running pipeline.py with example_gpu.cfg, with GPU & fp64 selected."
+echo "Running pipeline.py with example.cfg, with GPU & fp64 selected."
 echo "Storing results to"
 echo "  $OUTDIR_GPU64_NH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
-	-p settings/pipeline/example_gpu.cfg \
+	-p settings/pipeline/example.cfg \
 	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "nh" \
@@ -130,12 +128,12 @@ PISA_FTYPE=float64 python $PISA/pisa/core/pipeline.py \
 
 OUTDIR_GPU32_NH_PIPELINE=$TMP/gpu32nh_pipeline
 echo "=============================================================================="
-echo "Running pipeline.py with example_gpu.cfg, with GPU & fp32 selected."
+echo "Running pipeline.py with example.cfg, with GPU & fp32 selected."
 echo "Storing results to"
 echo "  $OUTDIR_GPU32_NH_PIPELINE"
 echo "=============================================================================="
 PISA_FTYPE=float32 python $PISA/pisa/core/pipeline.py \
-	-p settings/pipeline/example_gpu.cfg \
+	-p settings/pipeline/example.cfg \
 	-a stage.aeff param.aeff_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	-a stage.reco param.reco_events=events/events__vlvnt__toy_1_to_80GeV_spidx1.0_cz-1_to_1_1e5evts_set0__unjoined.hdf5 \
 	--select "nh" \

--- a/pisa_tests/test_example_pipelines.py
+++ b/pisa_tests/test_example_pipelines.py
@@ -83,14 +83,12 @@ def test_example_pipelines(ignore_gpu=False, ignore_root=False,
 
         except ImportError as err:
             exc = sys.exc_info()
-            if any(errstr in err.message for errstr in root_err_strings) and \
-              ignore_root:
+            if any(errstr in str(err) for errstr in root_err_strings) and ignore_root:
                 skip_count += 1
                 allow_error = True
                 msg = ('    Skipping pipeline, %s, as it has ROOT dependencies'
                        ' (ROOT cannot be imported)'%settings_file)
-            elif any(errstr in err.message for errstr in cuda_err_strings) and \
-              ignore_gpu:
+            elif any(errstr in str(err) for errstr in cuda_err_strings) and ignore_gpu:
                 skip_count += 1
                 allow_error = True
                 msg = ('    Skipping pipeline, %s, as it has cuda dependencies'
@@ -100,7 +98,7 @@ def test_example_pipelines(ignore_gpu=False, ignore_root=False,
 
         except IOError as err:
             exc = sys.exc_info()
-            match = re.match(missing_data_string, err.message, re.M|re.I)
+            match = re.match(missing_data_string, str(err), re.M|re.I)
             if match is not None and ignore_missing_data:
                 skip_count += 1
                 allow_error = True

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ def do_setup():
             'line_profiler',
             'matplotlib>=3.0', # 1.5: inferno colormap; 2.0: 'C0' colorspec
             'pint>=0.8', # earlier versions buggy
-            'kde',
+            'kde @ git+https://github.com/icecubeopensource/kde.git',
             'simplejson>=3.2',
             'tables',
             'uncertainties',


### PR DESCRIPTION
Should fix issue #543 , issue #551 , and other things
* allow `recursiveEquality` function to handle comparing non-float numpy arrays
* json write / read handles integer types
* improved unit testing function in `jsons.py`: `test_to_json_from_json`
* expose all constants, functions, and classes in `jsons.py`
* more python 3 compatibility fixes
* lots of stuff; see commit messages