### PR TITLE
Fix iteration of container dictionaries after Py3 switch.

### DIFF
--- a/pisa/core/container.py
+++ b/pisa/core/container.py
@@ -11,10 +11,10 @@ from __future__ import absolute_import, print_function
 from collections.abc import Sequence
 from collections import OrderedDict
 
+from itertools import chain
+
 import numpy as np
 from numba import SmartArray
-
-from itertools import chain
 
 from pisa import FTYPE
 from pisa.core.binning import OneDimBinning, MultiDimBinning

--- a/pisa/core/container.py
+++ b/pisa/core/container.py
@@ -14,13 +14,14 @@ from collections import OrderedDict
 import numpy as np
 from numba import SmartArray
 
+from itertools import chain
+
 from pisa import FTYPE
 from pisa.core.binning import OneDimBinning, MultiDimBinning
 from pisa.core.map import Map, MapSet
 from pisa.core.translation import histogram, lookup, resample
 from pisa.utils.log import logging
 
-from itertools import chain
 
 class ContainerSet(object):
     '''

--- a/pisa/core/container.py
+++ b/pisa/core/container.py
@@ -20,6 +20,7 @@ from pisa.core.map import Map, MapSet
 from pisa.core.translation import histogram, lookup, resample
 from pisa.utils.log import logging
 
+from itertools import chain
 
 class ContainerSet(object):
     '''
@@ -257,9 +258,9 @@ class Container(object):
         return list of available keys
         '''
         if self.data_mode == 'events':
-            return self.array_data.keys() + self.scalar_data.keys()
+            return chain(self.array_data.keys(), self.scalar_data.keys())
         elif self.data_mode == 'binned':
-            return self.array_data.keys() + self.scalar_data.keys() + self.data_specs.names
+            return chain(self.array_data.keys(), self.scalar_data.keys(), self.data_specs.names)
         else:
             raise ValueError('Need to set data specs first')
 
@@ -377,7 +378,7 @@ class Container(object):
         '''
         iterate over all keys in container
         '''
-        return iter(self.keys())
+        return self.keys()
 
     def array_to_binned(self, key, binning, averaged=True):
         '''

--- a/pisa/core/container.py
+++ b/pisa/core/container.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, print_function
 
 from collections.abc import Sequence
 from collections import OrderedDict
-
 from itertools import chain
 
 import numpy as np


### PR DESCRIPTION
This should fix issues with how dict.keys() works in Python 3.