### PR TITLE
Fixes for Tom's naming convention changes, remove py2 deps, add config docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,27 +77,27 @@ Also note that Python, HDF5, and pip support come pre-packaged or as `conda`-ins
     `sudo apt install llvm-3.9-dev`
 
 Required Python modules that are installed automatically when you use the `pip` command detailed later:
-* [configparser](https://pypi.python.org/pypi/configparser)
 * [decorator](https://pypi.python.org/pypi/decorator)
 * [h5py](http://www.h5py.org)
-* [line_profiler](https://pypi.python.org/pypi/line_profiler): detailed profiling output<br>
-  * if automatic pip installation of line_profiler fails, you may want to try `conda install line_profiler` if you are using anaconda
-* [matplotlib](http://matplotlib.org) >= 2.0 required
-* [numpy](http://www.numpy.org) version >= 1.11.0 required
-* [pint](https://pint.readthedocs.org) >= 0.8 required
-  * if automatic pip installation of pint fails, you may want to try `conda install pint` if you are using anaconda
-* [scipy](http://www.scipy.org) version >= 0.17 required
-* [setuptools](https://setuptools.readthedocs.io) version >= 0.18 required
-* [simplejson](https://github.com/simplejson/simplejson) version >= 3.2.0 required
-* [tables](http://www.pytables.org)
-* [uncertainties](https://pythonhosted.org/uncertainties)
-* [numba>=0.38](http://numba.pydata.org) Just-in-time compilation of decorated Python functions to native machine code via LLVM. This package is required to use PISA pi; also in cake it can accelerate certain routines significantly. If not using Anaconda to install, you must have LLVM installed already on your system (see above).
+* [iminuit](): Python interface to the MINUIT2 C++ package, used for proper covariance matrices during minimization
 * [kde](https://github.com/IceCubeOpenSource/kde)
   * You can install the `kde` module manually if it fails to install automatically:
     * Including CUDA support:<br>
       `pip install git+https://github.com/icecubeopensource/kde.git#egg=kde[cuda]`
     * Without CUDA support:<br>
       `pip install git+https://github.com/icecubeopensource/kde.git#egg=kde`
+* [line_profiler](https://pypi.python.org/pypi/line_profiler): detailed profiling output<br>
+  * if automatic pip installation of line_profiler fails, you may want to try `conda install line_profiler` if you are using anaconda
+* [matplotlib](http://matplotlib.org) >= 2.0 required
+* [numba==0.43.1](http://numba.pydata.org) Just-in-time compilation of decorated Python functions to native machine code via LLVM. This package is required to use PISA pi; also in cake it can accelerate certain routines significantly. If not using Anaconda to install, you must have LLVM installed already on your system (see above).
+* [numpy](http://www.numpy.org) version >= 1.17 required
+* [pint>=0.8](https://pint.readthedocs.org) >= 0.8 required
+  * if automatic pip installation of pint fails, you may want to try `conda install pint` if you are using anaconda
+* [scipy](http://www.scipy.org) version >= 0.17 required
+* [setuptools](https://setuptools.readthedocs.io) version >= 18.5 required
+* [simplejson](https://github.com/simplejson/simplejson) version >= 3.2.0 required
+* [tables](http://www.pytables.org)
+* [uncertainties](https://pythonhosted.org/uncertainties)
 
 
 ### Optional Dependencies

--- a/docs/source/pisa.analysis.rst
+++ b/docs/source/pisa.analysis.rst
@@ -1,27 +1,27 @@
-pisa.analysis package
-=====================
+pisa\.analysis package
+======================
 
 Submodules
 ----------
 
-pisa.analysis.analysis module
------------------------------
+pisa\.analysis\.analysis module
+-------------------------------
 
 .. automodule:: pisa.analysis.analysis
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.analysis.hypo\_testing module
-----------------------------------
+pisa\.analysis\.hypo\_testing module
+------------------------------------
 
 .. automodule:: pisa.analysis.hypo_testing
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.analysis.nutau\_analysis module
-------------------------------------
+pisa\.analysis\.nutau\_analysis module
+--------------------------------------
 
 .. automodule:: pisa.analysis.nutau_analysis
     :members:

--- a/docs/source/pisa.core.rst
+++ b/docs/source/pisa.core.rst
@@ -1,123 +1,123 @@
-pisa.core package
-=================
+pisa\.core package
+==================
 
 Submodules
 ----------
 
-pisa.core.base\_stage module
-----------------------------
+pisa\.core\.base\_stage module
+------------------------------
 
 .. automodule:: pisa.core.base_stage
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.binning module
-------------------------
+pisa\.core\.binning module
+--------------------------
 
 .. automodule:: pisa.core.binning
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.container module
---------------------------
+pisa\.core\.container module
+----------------------------
 
 .. automodule:: pisa.core.container
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.detectors module
---------------------------
+pisa\.core\.detectors module
+----------------------------
 
 .. automodule:: pisa.core.detectors
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.distribution\_maker module
-------------------------------------
+pisa\.core\.distribution\_maker module
+--------------------------------------
 
 .. automodule:: pisa.core.distribution_maker
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.events module
------------------------
+pisa\.core\.events module
+-------------------------
 
 .. automodule:: pisa.core.events
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.events\_pi module
----------------------------
+pisa\.core\.events\_pi module
+-----------------------------
 
 .. automodule:: pisa.core.events_pi
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.map module
---------------------
+pisa\.core\.map module
+----------------------
 
 .. automodule:: pisa.core.map
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.param module
-----------------------
+pisa\.core\.param module
+------------------------
 
 .. automodule:: pisa.core.param
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.pi\_stage module
---------------------------
+pisa\.core\.pi\_stage module
+----------------------------
 
 .. automodule:: pisa.core.pi_stage
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.pipeline module
--------------------------
+pisa\.core\.pipeline module
+---------------------------
 
 .. automodule:: pisa.core.pipeline
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.prior module
-----------------------
+pisa\.core\.prior module
+------------------------
 
 .. automodule:: pisa.core.prior
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.stage module
-----------------------
+pisa\.core\.stage module
+------------------------
 
 .. automodule:: pisa.core.stage
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.transform module
---------------------------
+pisa\.core\.transform module
+----------------------------
 
 .. automodule:: pisa.core.transform
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.core.translation module
-----------------------------
+pisa\.core\.translation module
+------------------------------
 
 .. automodule:: pisa.core.translation
     :members:

--- a/docs/source/pisa.scripts.rst
+++ b/docs/source/pisa.scripts.rst
@@ -1,171 +1,163 @@
-pisa.scripts package
-====================
+pisa\.scripts package
+=====================
 
 Submodules
 ----------
 
-pisa.scripts.add\_flux\_to\_events\_file module
------------------------------------------------
+pisa\.scripts\.add\_flux\_to\_events\_file module
+-------------------------------------------------
 
 .. automodule:: pisa.scripts.add_flux_to_events_file
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.analysis module
-----------------------------
+pisa\.scripts\.analysis module
+------------------------------
 
 .. automodule:: pisa.scripts.analysis
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.analysis\_postprocess module
------------------------------------------
+pisa\.scripts\.analysis\_postprocess module
+-------------------------------------------
 
 .. automodule:: pisa.scripts.analysis_postprocess
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.compare module
----------------------------
+pisa\.scripts\.compare module
+-----------------------------
 
 .. automodule:: pisa.scripts.compare
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.convert\_config\_format module
--------------------------------------------
+pisa\.scripts\.convert\_config\_format module
+---------------------------------------------
 
 .. automodule:: pisa.scripts.convert_config_format
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.create\_barr\_sys\_tables\_mceq module
----------------------------------------------------
+pisa\.scripts\.create\_barr\_sys\_tables\_mceq module
+-----------------------------------------------------
 
 .. automodule:: pisa.scripts.create_barr_sys_tables_mceq
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.discrete\_hypo\_test module
-----------------------------------------
+pisa\.scripts\.discrete\_hypo\_test module
+------------------------------------------
 
 .. automodule:: pisa.scripts.discrete_hypo_test
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.fit\_discrete\_sys module
+pisa\.scripts\.fit\_hypersurfaces module
+----------------------------------------
+
+.. automodule:: pisa.scripts.fit_hypersurfaces
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.scripts\.inj\_param\_scan module
 --------------------------------------
-
-.. automodule:: pisa.scripts.fit_discrete_sys
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-pisa.scripts.fit\_discrete\_sys\_nd module
-------------------------------------------
-
-.. automodule:: pisa.scripts.fit_discrete_sys_nd
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-pisa.scripts.inj\_param\_scan module
-------------------------------------
 
 .. automodule:: pisa.scripts.inj_param_scan
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.make\_asymmetry\_plots module
-------------------------------------------
+pisa\.scripts\.make\_asymmetry\_plots module
+--------------------------------------------
 
 .. automodule:: pisa.scripts.make_asymmetry_plots
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.make\_events\_file module
---------------------------------------
+pisa\.scripts\.make\_events\_file module
+----------------------------------------
 
 .. automodule:: pisa.scripts.make_events_file
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.make\_nufit\_theta23\_spline\_priors module
---------------------------------------------------------
+pisa\.scripts\.make\_nufit\_theta23\_spline\_priors module
+----------------------------------------------------------
 
 .. automodule:: pisa.scripts.make_nufit_theta23_spline_priors
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.make\_systematic\_variation\_plots module
-------------------------------------------------------
+pisa\.scripts\.make\_systematic\_variation\_plots module
+--------------------------------------------------------
 
 .. automodule:: pisa.scripts.make_systematic_variation_plots
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.make\_toy\_events module
--------------------------------------
+pisa\.scripts\.make\_toy\_events module
+---------------------------------------
 
 .. automodule:: pisa.scripts.make_toy_events
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.param\_scan module
--------------------------------
+pisa\.scripts\.param\_scan module
+---------------------------------
 
 .. automodule:: pisa.scripts.param_scan
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.profile\_scan module
----------------------------------
+pisa\.scripts\.profile\_scan module
+-----------------------------------
 
 .. automodule:: pisa.scripts.profile_scan
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.scan\_allsyst module
----------------------------------
+pisa\.scripts\.scan\_allsyst module
+-----------------------------------
 
 .. automodule:: pisa.scripts.scan_allsyst
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.smooth\_pid module
--------------------------------
+pisa\.scripts\.smooth\_pid module
+---------------------------------
 
 .. automodule:: pisa.scripts.smooth_pid
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.systematics\_tests module
---------------------------------------
+pisa\.scripts\.systematics\_tests module
+----------------------------------------
 
 .. automodule:: pisa.scripts.systematics_tests
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.scripts.test\_flux\_weights module
----------------------------------------
+pisa\.scripts\.test\_flux\_weights module
+-----------------------------------------
 
 .. automodule:: pisa.scripts.test_flux_weights
     :members:

--- a/docs/source/pisa.stages.absorption.rst
+++ b/docs/source/pisa.stages.absorption.rst
@@ -1,0 +1,22 @@
+pisa\.stages\.absorption package
+================================
+
+Submodules
+----------
+
+pisa\.stages\.absorption\.pi\_earth\_absorption module
+------------------------------------------------------
+
+.. automodule:: pisa.stages.absorption.pi_earth_absorption
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pisa.stages.absorption
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pisa.stages.aeff.rst
+++ b/docs/source/pisa.stages.aeff.rst
@@ -1,43 +1,43 @@
-pisa.stages.aeff package
-========================
+pisa\.stages\.aeff package
+==========================
 
 Submodules
 ----------
 
-pisa.stages.aeff.hist module
-----------------------------
+pisa\.stages\.aeff\.hist module
+-------------------------------
 
 .. automodule:: pisa.stages.aeff.hist
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.aeff.param module
------------------------------
+pisa\.stages\.aeff\.param module
+--------------------------------
 
 .. automodule:: pisa.stages.aeff.param
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.aeff.pi\_aeff module
---------------------------------
+pisa\.stages\.aeff\.pi\_aeff module
+-----------------------------------
 
 .. automodule:: pisa.stages.aeff.pi_aeff
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.aeff.pi\_weight module
-----------------------------------
+pisa\.stages\.aeff\.pi\_weight module
+-------------------------------------
 
 .. automodule:: pisa.stages.aeff.pi_weight
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.aeff.smooth module
-------------------------------
+pisa\.stages\.aeff\.smooth module
+---------------------------------
 
 .. automodule:: pisa.stages.aeff.smooth
     :members:

--- a/docs/source/pisa.stages.background.rst
+++ b/docs/source/pisa.stages.background.rst
@@ -1,11 +1,11 @@
-pisa.stages.background package
-==============================
+pisa\.stages\.background package
+================================
 
 Submodules
 ----------
 
-pisa.stages.background.atm\_muons module
-----------------------------------------
+pisa\.stages\.background\.atm\_muons module
+-------------------------------------------
 
 .. automodule:: pisa.stages.background.atm_muons
     :members:

--- a/docs/source/pisa.stages.combine.rst
+++ b/docs/source/pisa.stages.combine.rst
@@ -1,11 +1,11 @@
-pisa.stages.combine package
-===========================
+pisa\.stages\.combine package
+=============================
 
 Submodules
 ----------
 
-pisa.stages.combine.nutau module
---------------------------------
+pisa\.stages\.combine\.nutau module
+-----------------------------------
 
 .. automodule:: pisa.stages.combine.nutau
     :members:

--- a/docs/source/pisa.stages.data.rst
+++ b/docs/source/pisa.stages.data.rst
@@ -1,51 +1,83 @@
-pisa.stages.data package
-========================
+pisa\.stages\.data package
+==========================
 
 Submodules
 ----------
 
-pisa.stages.data.data module
-----------------------------
+pisa\.stages\.data\.csv\_data\_hist module
+------------------------------------------
+
+.. automodule:: pisa.stages.data.csv_data_hist
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.data\.csv\_icc\_hist module
+-----------------------------------------
+
+.. automodule:: pisa.stages.data.csv_icc_hist
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.data\.csv\_loader module
+--------------------------------------
+
+.. automodule:: pisa.stages.data.csv_loader
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.data\.data module
+-------------------------------
 
 .. automodule:: pisa.stages.data.data
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.data.events\_to\_data module
-----------------------------------------
+pisa\.stages\.data\.events\_to\_data module
+-------------------------------------------
 
 .. automodule:: pisa.stages.data.events_to_data
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.data.icc module
----------------------------
+pisa\.stages\.data\.grid module
+-------------------------------
+
+.. automodule:: pisa.stages.data.grid
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.data\.icc module
+------------------------------
 
 .. automodule:: pisa.stages.data.icc
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.data.sample module
-------------------------------
+pisa\.stages\.data\.sample module
+---------------------------------
 
 .. automodule:: pisa.stages.data.sample
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.data.simple\_data\_loader module
---------------------------------------------
+pisa\.stages\.data\.simple\_data\_loader module
+-----------------------------------------------
 
 .. automodule:: pisa.stages.data.simple_data_loader
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.data.toy\_event\_generator module
----------------------------------------------
+pisa\.stages\.data\.toy\_event\_generator module
+------------------------------------------------
 
 .. automodule:: pisa.stages.data.toy_event_generator
     :members:

--- a/docs/source/pisa.stages.discr_sys.rst
+++ b/docs/source/pisa.stages.discr_sys.rst
@@ -1,35 +1,35 @@
-pisa.stages.discr\_sys package
-==============================
+pisa\.stages\.discr\_sys package
+================================
 
 Submodules
 ----------
 
-pisa.stages.discr\_sys.fit module
----------------------------------
+pisa\.stages\.discr\_sys\.fit module
+------------------------------------
 
 .. automodule:: pisa.stages.discr_sys.fit
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.discr\_sys.hyperplane module
-----------------------------------------
+pisa\.stages\.discr\_sys\.hyperplane module
+-------------------------------------------
 
 .. automodule:: pisa.stages.discr_sys.hyperplane
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.discr\_sys.pi\_hyperplanes module
----------------------------------------------
+pisa\.stages\.discr\_sys\.pi\_hypersurfaces module
+--------------------------------------------------
 
-.. automodule:: pisa.stages.discr_sys.pi_hyperplanes
+.. automodule:: pisa.stages.discr_sys.pi_hypersurfaces
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.discr\_sys.polyfits module
---------------------------------------
+pisa\.stages\.discr\_sys\.polyfits module
+-----------------------------------------
 
 .. automodule:: pisa.stages.discr_sys.polyfits
     :members:

--- a/docs/source/pisa.stages.flux.rst
+++ b/docs/source/pisa.stages.flux.rst
@@ -1,53 +1,53 @@
-pisa.stages.flux package
-========================
+pisa\.stages\.flux package
+==========================
 
 Submodules
 ----------
 
-pisa.stages.flux.dummy module
------------------------------
+pisa\.stages\.flux\.dummy module
+--------------------------------
 
 .. automodule:: pisa.stages.flux.dummy
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.flux.honda module
------------------------------
+pisa\.stages\.flux\.honda module
+--------------------------------
 
 .. automodule:: pisa.stages.flux.honda
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.flux.mceq module
-----------------------------
+pisa\.stages\.flux\.mceq module
+-------------------------------
 
 .. automodule:: pisa.stages.flux.mceq
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.flux.pi\_honda\_ip module
--------------------------------------
+pisa\.stages\.flux\.pi\_barr\_simple module
+-------------------------------------------
+
+.. automodule:: pisa.stages.flux.pi_barr_simple
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.flux\.pi\_honda\_ip module
+----------------------------------------
 
 .. automodule:: pisa.stages.flux.pi_honda_ip
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.flux.pi\_mceq\_barr module
---------------------------------------
+pisa\.stages\.flux\.pi\_mceq\_barr module
+-----------------------------------------
 
 .. automodule:: pisa.stages.flux.pi_mceq_barr
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-pisa.stages.flux.pi\_simple module
-----------------------------------
-
-.. automodule:: pisa.stages.flux.pi_barr_simple
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/pisa.stages.flux.rst
+++ b/docs/source/pisa.stages.flux.rst
@@ -47,7 +47,7 @@ pisa.stages.flux.pi\_mceq\_barr module
 pisa.stages.flux.pi\_simple module
 ----------------------------------
 
-.. automodule:: pisa.stages.flux.pi_simple
+.. automodule:: pisa.stages.flux.pi_barr_simple
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/pisa.stages.osc.nusquids.rst
+++ b/docs/source/pisa.stages.osc.nusquids.rst
@@ -1,11 +1,11 @@
-pisa.stages.osc.nusquids package
-================================
+pisa\.stages\.osc\.nusquids package
+===================================
 
 Submodules
 ----------
 
-pisa.stages.osc.nusquids.nusquids\_osc module
----------------------------------------------
+pisa\.stages\.osc\.nusquids\.nusquids\_osc module
+-------------------------------------------------
 
 .. automodule:: pisa.stages.osc.nusquids.nusquids_osc
     :members:

--- a/docs/source/pisa.stages.osc.prob3numba.rst
+++ b/docs/source/pisa.stages.osc.prob3numba.rst
@@ -1,19 +1,19 @@
-pisa.stages.osc.prob3numba package
-==================================
+pisa\.stages\.osc\.prob3numba package
+=====================================
 
 Submodules
 ----------
 
-pisa.stages.osc.prob3numba.numba\_osc module
---------------------------------------------
+pisa\.stages\.osc\.prob3numba\.numba\_osc module
+------------------------------------------------
 
 .. automodule:: pisa.stages.osc.prob3numba.numba_osc
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.prob3numba.test\_numba module
----------------------------------------------
+pisa\.stages\.osc\.prob3numba\.test\_numba module
+-------------------------------------------------
 
 .. automodule:: pisa.stages.osc.prob3numba.test_numba
     :members:

--- a/docs/source/pisa.stages.osc.rst
+++ b/docs/source/pisa.stages.osc.rst
@@ -1,83 +1,83 @@
-pisa.stages.osc package
-=======================
-
-Subpackages
------------
-
-.. toctree::
-
-    pisa.stages.osc.nusquids
-    pisa.stages.osc.prob3numba
+pisa\.stages\.osc package
+=========================
 
 Submodules
 ----------
 
-pisa.stages.osc.cake\_nusquids module
--------------------------------------
+pisa\.stages\.osc\.cake\_nusquids module
+----------------------------------------
 
 .. automodule:: pisa.stages.osc.cake_nusquids
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.decoherence module
-----------------------------------
+pisa\.stages\.osc\.decoherence module
+-------------------------------------
 
 .. automodule:: pisa.stages.osc.decoherence
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.dummy module
-----------------------------
+pisa\.stages\.osc\.dummy module
+-------------------------------
 
 .. automodule:: pisa.stages.osc.dummy
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.layers module
------------------------------
+pisa\.stages\.osc\.layers module
+--------------------------------
 
 .. automodule:: pisa.stages.osc.layers
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.nsi\_params module
-----------------------------------
+pisa\.stages\.osc\.nsi\_params module
+-------------------------------------
 
 .. automodule:: pisa.stages.osc.nsi_params
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.osc\_params module
-----------------------------------
+pisa\.stages\.osc\.osc\_params module
+-------------------------------------
 
 .. automodule:: pisa.stages.osc.osc_params
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.pi\_nusquids module
------------------------------------
+pisa\.stages\.osc\.pi\_globes module
+------------------------------------
+
+.. automodule:: pisa.stages.osc.pi_globes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.osc\.pi\_nusquids module
+--------------------------------------
 
 .. automodule:: pisa.stages.osc.pi_nusquids
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.pi\_osc\_params module
---------------------------------------
+pisa\.stages\.osc\.pi\_osc\_params module
+-----------------------------------------
 
 .. automodule:: pisa.stages.osc.pi_osc_params
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.osc.pi\_prob3 module
---------------------------------
+pisa\.stages\.osc\.pi\_prob3 module
+-----------------------------------
 
 .. automodule:: pisa.stages.osc.pi_prob3
     :members:

--- a/docs/source/pisa.stages.pid.rst
+++ b/docs/source/pisa.stages.pid.rst
@@ -1,27 +1,35 @@
-pisa.stages.pid package
-=======================
+pisa\.stages\.pid package
+=========================
 
 Submodules
 ----------
 
-pisa.stages.pid.hist module
----------------------------
+pisa\.stages\.pid\.hist module
+------------------------------
 
 .. automodule:: pisa.stages.pid.hist
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.pid.param module
-----------------------------
+pisa\.stages\.pid\.param module
+-------------------------------
 
 .. automodule:: pisa.stages.pid.param
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.pid.smooth module
------------------------------
+pisa\.stages\.pid\.pi\_shift\_scale\_pid module
+-----------------------------------------------
+
+.. automodule:: pisa.stages.pid.pi_shift_scale_pid
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.stages\.pid\.smooth module
+--------------------------------
 
 .. automodule:: pisa.stages.pid.smooth
     :members:

--- a/docs/source/pisa.stages.reco.rst
+++ b/docs/source/pisa.stages.reco.rst
@@ -1,43 +1,43 @@
-pisa.stages.reco package
-========================
+pisa\.stages\.reco package
+==========================
 
 Submodules
 ----------
 
-pisa.stages.reco.hist module
-----------------------------
+pisa\.stages\.reco\.hist module
+-------------------------------
 
 .. automodule:: pisa.stages.reco.hist
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.reco.param module
------------------------------
+pisa\.stages\.reco\.param module
+--------------------------------
 
 .. automodule:: pisa.stages.reco.param
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.reco.resolutions module
------------------------------------
+pisa\.stages\.reco\.resolutions module
+--------------------------------------
 
 .. automodule:: pisa.stages.reco.resolutions
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.reco.simple\_param module
--------------------------------------
+pisa\.stages\.reco\.simple\_param module
+----------------------------------------
 
 .. automodule:: pisa.stages.reco.simple_param
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.reco.vbwkde module
-------------------------------
+pisa\.stages\.reco\.vbwkde module
+---------------------------------
 
 .. automodule:: pisa.stages.reco.vbwkde
     :members:

--- a/docs/source/pisa.stages.rst
+++ b/docs/source/pisa.stages.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    pisa.stages.absorption
     pisa.stages.aeff
     pisa.stages.background
     pisa.stages.combine

--- a/docs/source/pisa.stages.unfold.rst
+++ b/docs/source/pisa.stages.unfold.rst
@@ -1,11 +1,11 @@
-pisa.stages.unfold package
-==========================
+pisa\.stages\.unfold package
+============================
 
 Submodules
 ----------
 
-pisa.stages.unfold.roounfold module
------------------------------------
+pisa\.stages\.unfold\.roounfold module
+--------------------------------------
 
 .. automodule:: pisa.stages.unfold.roounfold
     :members:

--- a/docs/source/pisa.stages.utils.rst
+++ b/docs/source/pisa.stages.utils.rst
@@ -1,11 +1,11 @@
-pisa.stages.utils package
-=========================
+pisa\.stages\.utils package
+===========================
 
 Submodules
 ----------
 
-pisa.stages.utils.pi\_hist module
----------------------------------
+pisa\.stages\.utils\.pi\_hist module
+------------------------------------
 
 .. automodule:: pisa.stages.utils.pi_hist
     :members:

--- a/docs/source/pisa.stages.xsec.rst
+++ b/docs/source/pisa.stages.xsec.rst
@@ -1,19 +1,19 @@
-pisa.stages.xsec package
-========================
+pisa\.stages\.xsec package
+==========================
 
 Submodules
 ----------
 
-pisa.stages.xsec.genie module
------------------------------
+pisa\.stages\.xsec\.genie module
+--------------------------------
 
 .. automodule:: pisa.stages.xsec.genie
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.stages.xsec.genie\_sys module
-----------------------------------
+pisa\.stages\.xsec\.genie\_sys module
+-------------------------------------
 
 .. automodule:: pisa.stages.xsec.genie_sys
     :members:

--- a/docs/source/pisa.utils.rst
+++ b/docs/source/pisa.utils.rst
@@ -1,299 +1,331 @@
-pisa.utils package
-==================
+pisa\.utils package
+===================
 
 Submodules
 ----------
 
-pisa.utils.PIDSpec module
--------------------------
+pisa\.utils\.PIDSpec module
+---------------------------
 
 .. automodule:: pisa.utils.PIDSpec
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.barlow module
-------------------------
+pisa\.utils\.barlow module
+--------------------------
 
 .. automodule:: pisa.utils.barlow
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.cache module
------------------------
+pisa\.utils\.cache module
+-------------------------
 
 .. automodule:: pisa.utils.cache
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.comparisons module
------------------------------
+pisa\.utils\.comparisons module
+-------------------------------
 
 .. automodule:: pisa.utils.comparisons
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.confInterval module
-------------------------------
+pisa\.utils\.confInterval module
+--------------------------------
 
 .. automodule:: pisa.utils.confInterval
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.config\_parser module
---------------------------------
+pisa\.utils\.config\_parser module
+----------------------------------
 
 .. automodule:: pisa.utils.config_parser
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.coords module
-------------------------
+pisa\.utils\.coords module
+--------------------------
 
 .. automodule:: pisa.utils.coords
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.cross\_sections module
----------------------------------
+pisa\.utils\.cross\_sections module
+-----------------------------------
 
 .. automodule:: pisa.utils.cross_sections
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.data\_proc\_params module
-------------------------------------
+pisa\.utils\.data\_proc\_params module
+--------------------------------------
 
 .. automodule:: pisa.utils.data_proc_params
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.fileio module
-------------------------
+pisa\.utils\.fileio module
+--------------------------
 
 .. automodule:: pisa.utils.fileio
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.flavInt module
--------------------------
+pisa\.utils\.flavInt module
+---------------------------
 
 .. automodule:: pisa.utils.flavInt
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.flux\_weights module
--------------------------------
+pisa\.utils\.flux\_weights module
+---------------------------------
 
 .. automodule:: pisa.utils.flux_weights
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.format module
-------------------------
+pisa\.utils\.format module
+--------------------------
 
 .. automodule:: pisa.utils.format
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.gaussians module
----------------------------
+pisa\.utils\.gaussians module
+-----------------------------
 
 .. automodule:: pisa.utils.gaussians
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.hash module
-----------------------
+pisa\.utils\.hash module
+------------------------
 
 .. automodule:: pisa.utils.hash
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.hdf module
----------------------
+pisa\.utils\.hdf module
+-----------------------
 
 .. automodule:: pisa.utils.hdf
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.hdfchain module
---------------------------
+pisa\.utils\.hdfchain module
+----------------------------
 
 .. automodule:: pisa.utils.hdfchain
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.jsons module
------------------------
+pisa\.utils\.hypersurface module
+--------------------------------
+
+.. automodule:: pisa.utils.hypersurface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.utils\.jsons module
+-------------------------
 
 .. automodule:: pisa.utils.jsons
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.kde\_hist module
----------------------------
+pisa\.utils\.kde\_hist module
+-----------------------------
 
 .. automodule:: pisa.utils.kde_hist
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.log module
----------------------
+pisa\.utils\.likelihood\_functions module
+-----------------------------------------
+
+.. automodule:: pisa.utils.likelihood_functions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.utils\.llh\_client module
+-------------------------------
+
+.. automodule:: pisa.utils.llh_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.utils\.llh\_server module
+-------------------------------
+
+.. automodule:: pisa.utils.llh_server
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pisa\.utils\.log module
+-----------------------
 
 .. automodule:: pisa.utils.log
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.mcSimRunSettings module
-----------------------------------
+pisa\.utils\.mcSimRunSettings module
+------------------------------------
 
 .. automodule:: pisa.utils.mcSimRunSettings
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.numba\_tools module
-------------------------------
+pisa\.utils\.numba\_tools module
+--------------------------------
 
 .. automodule:: pisa.utils.numba_tools
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.parallel module
---------------------------
+pisa\.utils\.parallel module
+----------------------------
 
 .. automodule:: pisa.utils.parallel
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.plotter module
--------------------------
+pisa\.utils\.plotter module
+---------------------------
 
 .. automodule:: pisa.utils.plotter
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.postprocess module
------------------------------
+pisa\.utils\.postprocess module
+-------------------------------
 
 .. automodule:: pisa.utils.postprocess
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.profiler module
---------------------------
+pisa\.utils\.profiler module
+----------------------------
 
 .. automodule:: pisa.utils.profiler
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.random\_numbers module
----------------------------------
+pisa\.utils\.random\_numbers module
+-----------------------------------
 
 .. automodule:: pisa.utils.random_numbers
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.resources module
----------------------------
+pisa\.utils\.resources module
+-----------------------------
 
 .. automodule:: pisa.utils.resources
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.rooutils module
---------------------------
+pisa\.utils\.rooutils module
+----------------------------
 
 .. automodule:: pisa.utils.rooutils
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.scripting module
----------------------------
+pisa\.utils\.scripting module
+-----------------------------
 
 .. automodule:: pisa.utils.scripting
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.spline module
-------------------------
+pisa\.utils\.spline module
+--------------------------
 
 .. automodule:: pisa.utils.spline
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.spline\_smooth module
---------------------------------
+pisa\.utils\.spline\_smooth module
+----------------------------------
 
 .. automodule:: pisa.utils.spline_smooth
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.stats module
------------------------
+pisa\.utils\.stats module
+-------------------------
 
 .. automodule:: pisa.utils.stats
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.tests module
------------------------
+pisa\.utils\.tests module
+-------------------------
 
 .. automodule:: pisa.utils.tests
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.timer module
------------------------
+pisa\.utils\.timer module
+-------------------------
 
 .. automodule:: pisa.utils.timer
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.vbwkde module
-------------------------
+pisa\.utils\.vbwkde module
+--------------------------
 
 .. automodule:: pisa.utils.vbwkde
     :members:
     :undoc-members:
     :show-inheritance:
 
-pisa.utils.vectorizer module
-----------------------------
+pisa\.utils\.vectorizer module
+------------------------------
 
 .. automodule:: pisa.utils.vectorizer
     :members:

--- a/pisa/scripts/convert_config_format.py
+++ b/pisa/scripts/convert_config_format.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-from backports.configparser import MissingSectionHeaderError
+from configparser import MissingSectionHeaderError
 
 from pisa.utils.config_parser import PISAConfigParser
 from pisa.utils.resources import find_resource

--- a/pisa/stages/GLOBALS.md
+++ b/pisa/stages/GLOBALS.md
@@ -51,7 +51,7 @@ Also note that where a service implements `FTYPE` and relies on C extension code
 | `flux.dummy`               | :black_square_button:    | :black_square_button: | :black_square_button: | :black_square_button: |
 | `flux.honda`               | :heavy_check_mark:       | :black_square_button: | :black_square_button: | :black_square_button: |
 | `flux.mceq`                | :black_square_button:    | :black_square_button: | :black_square_button: | :black_square_button: |
-| `flux.pi_simple`           | :heavy_exclamation_mark: | :heavy_check_mark:    | :black_square_button: | :heavy_check_mark:    |
+| `flux.pi_barr_simple`      | :heavy_exclamation_mark: | :heavy_check_mark:    | :black_square_button: | :heavy_check_mark:    |
 | `osc.pi_prob3`             | :heavy_exclamation_mark: | :heavy_check_mark:    | :black_square_button: | :heavy_check_mark:    |
 | `pid.hist`                 | :black_square_button:    | :black_square_button: | :black_square_button: | :black_square_button: |
 | `pid.param`                | :black_square_button:    | :black_square_button: | :black_square_button: | :black_square_button: |

--- a/pisa_examples/resources/settings/discr_sys/example_discr_sys.cfg
+++ b/pisa_examples/resources/settings/discr_sys/example_discr_sys.cfg
@@ -52,7 +52,7 @@ set [data.simple_data_loader] data_dict = {
     }
 
 # since we removed two sections, need to redefine the `stage.service`s
-set [pipeline] order = data.simple_data_loader, reco.resolutions, flux.pi_honda_ip, flux.pi_simple, osc.pi_prob3, aeff.pi_aeff, utils.pi_hist
+set [pipeline] order = data.simple_data_loader, reco.resolutions, flux.pi_honda_ip, flux.pi_barr_simple, osc.pi_prob3, aeff.pi_aeff, utils.pi_hist
 
 # set reco.resolutions params
 set [reco.resolutions] param.energy_improvement = ${general:energy_improvement}

--- a/pisa_examples/resources/settings/pipeline/example.cfg
+++ b/pisa_examples/resources/settings/pipeline/example.cfg
@@ -13,7 +13,7 @@
 
 # Define order of stages to be executed one after another, and specify the
 # service to use for each of them as stage1:serviceA, stage2:serviceB, ...
-order = data.simple_data_loader, flux.pi_simple, osc.pi_prob3, aeff.pi_aeff, utils.pi_hist
+order = data.simple_data_loader, flux.pi_barr_simple, osc.pi_prob3, aeff.pi_aeff, utils.pi_hist
 
 # Select the params denoted by param.<param_selector>.<param_name>
 # This feature allows a whole subset of parameters to be selected,
@@ -65,8 +65,8 @@ data_dict = {
     'reco_coszen': 'reco_coszen',
     'pid': 'pid',
     'weighted_aeff': 'weighted_aeff',
-    'nominal_nu_flux': ['nominal_nue_flux', 'nominal_numu_flux'],
-    'nominal_nubar_flux': ['nominal_nuebar_flux', 'nominal_numubar_flux']
+    'nu_flux_nominal': ['nominal_nue_flux', 'nominal_numu_flux'],
+    'nubar_flux_nominal': ['nominal_nuebar_flux', 'nominal_numubar_flux']
     }
 
 
@@ -79,7 +79,7 @@ data_dict = {
 # Right now the implementation is a parameterisation of the
 # Barr 2006 paper, plus handling for the spectral index.
 
-[flux.pi_simple]
+[flux.pi_barr_simple]
 
 input_specs = events
 calc_specs = events

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -9,7 +9,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#	http://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
@@ -70,7 +70,7 @@ do
 
 	echo "=============================================================================="
 	echo "Running python $BN at abs path"
-    echo "  `realpath $f`"
+	echo "  `realpath $f`"
 	echo "=============================================================================="
 	python $f || FAILURE=true
 	echo "------------------------------------------------------------------------------"
@@ -250,20 +250,5 @@ python $PISA/pisa/scripts/compare.py \
 #	--png -v
 
 
-# TODO: following fails unless we can use larger data set size!
-OUTDIR=$TMP/hypo_testing_test
-echo "=============================================================================="
-echo "Running hypo_testing.py, basic NMO Asimov analysis (not necessarily accurate)"
-echo "Storing results to"
-echo "  $OUTDIR"
-echo "=============================================================================="
-PISA_FTYPE=float32 python $PISA/pisa/scripts/analysis.py discrete_hypo \
-	--h0-pipeline settings/pipeline/example.cfg \
-	--h0-param-selections="ih" \
-	--h1-param-selections="nh" \
-	--data-param-selections="nh" \
-	--data-is-mc \
-	--min-settings settings/minimizer/l-bfgs-b_ftol2e-5_gtol1e-5_eps1e-4_maxiter200.json \
-	--metric=chi2 \
-	--logdir $OUTDIR \
-	--pprint -v --allow-dirty
+# Call script to run hypothesis testing (runs minimizer with a pipeline)
+$BASEDIR/test_hypo_testing.sh

--- a/pisa_tests/test_hypo_testing.sh
+++ b/pisa_tests/test_hypo_testing.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+#
+# author: J.L. Lanfranchi
+#
+# Copyright (c) 2014-2020, The IceCube Collaboration
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License
+#
+
+
+BASEDIR=$(dirname "$0")
+PISA=$BASEDIR/..
+TMP=/tmp/pisa_tests
+export PISA_RESOURCES=${TMP}/pisa_resources:$PISA_RESOURCES
+mkdir -p $TMP
+mkdir -p $PISA_RESOURCES
+echo "PISA=$PISA"
+
+
+echo "=============================================================================="
+echo "Generating toy MC for use with test scripts"
+echo "=============================================================================="
+PISA_FTYPE=float32 python $PISA/pisa/scripts/make_toy_events.py --outdir ${PISA_RESOURCES}/events \
+	--num-events 1e5 \
+	--energy-range 1 80 \
+	--spectral-index 1 \
+	--coszen-range -1 1
+echo "------------------------------------------------------------------------------"
+echo "Finished creating toy MC events to be used with unit tests"
+echo "------------------------------------------------------------------------------"
+echo ""
+echo ""
+
+
+# TODO: following fails unless we can use larger data set size!
+OUTDIR=$TMP/hypo_testing_test
+echo "=============================================================================="
+echo "Running hypo_testing.py, basic NMO Asimov analysis (not necessarily accurate)"
+echo "Storing results to"
+echo "  $OUTDIR"
+echo "=============================================================================="
+PISA_FTYPE=float32 python $PISA/pisa/scripts/analysis.py discrete_hypo \
+	--h0-pipeline settings/pipeline/test_repeated_params.cfg \
+	--h0-param-selections="ih" \
+	--h1-param-selections="nh" \
+	--data-param-selections="nh" \
+	--data-is-mc \
+	--min-settings settings/minimizer/l-bfgs-b_ftol2e-5_gtol1e-5_eps1e-4_maxiter200.json \
+	--metric=chi2 \
+	--logdir $OUTDIR \
+	--pprint -v --allow-dirty

--- a/setup.py
+++ b/setup.py
@@ -221,19 +221,18 @@ def do_setup():
             'numpy>=1.17'
         ],
         install_requires=[
-            'configparser',
-            'scipy>=0.17',
+            'decorator',
+            'kde @ git+https://github.com/icecubeopensource/kde.git',
             'h5py',
+            'iminuit',
             'line_profiler',
             'matplotlib>=3.0', # 1.5: inferno colormap; 2.0: 'C0' colorspec
+            'numba==0.43.1', # >=0.35: fastmath jit flag; >=0.38: issue #439, <0.44 because SmartArray deprication
             'pint>=0.8', # earlier versions buggy
-            'kde @ git+https://github.com/icecubeopensource/kde.git',
+            'scipy>=0.17',
             'simplejson>=3.2',
             'tables',
             'uncertainties',
-            'decorator',
-            'iminuit',
-            'numba==0.43.1', # >=0.35: fastmath jit flag; >=0.38: issue #439, <0.44 because SmartArray deprication
         ],
         extras_require={
             'develop': [


### PR DESCRIPTION
* bugfix: Tom changed naming conventions in some places but not everywhere, breaking example config and making docs out of date
  * `pi_simple` -> `pi_barr_simple`
  * `nominal_nu_flux` -> `nu_flux_nominal`, `nominal_nubar_flux` -> `nubar_flux_nominal`
* split hypo testing part of `test_command_lines.sh` into separate bash script that is individually callable to make testing just that piece easier / faster -> `test_hypo_testing.sh`
* document pisa config file param interpolation syntax; remove py2 `backports.configparser` dependency
* update dependencies listed in `INSTALL.md` & dependencies in `setup.py` to remove `backports.configparser`; add `iminuit` to dependency docs (not required for PISA to run, though, so only added to `INSTALL.md` not to `setup.py`)
* update built HTML docs