### PR TITLE
Fix matrix unit test and make small fix to binning

### DIFF
--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -2730,6 +2730,7 @@ class MultiDimBinning(object):
             for d in self.iterdims():
                 if d.name == index:
                     return d
+            raise ValueError(f"index '{index}' not in {[d.name for d in self.iterdims()]}")
 
         # TODO: implement a "linearization" like np.flatten() to iterate
         # through each bin individually without hassle for the user...

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -2730,7 +2730,7 @@ class MultiDimBinning(object):
             for d in self.iterdims():
                 if d.name == index:
                     return d
-            raise ValueError(f"index '{index}' not in {[d.name for d in self.iterdims()]}")
+            raise ValueError(f"index '{index}' not in {self.names}")
 
         # TODO: implement a "linearization" like np.flatten() to iterate
         # through each bin individually without hassle for the user...

--- a/pisa/utils/jsons.py
+++ b/pisa/utils/jsons.py
@@ -18,7 +18,7 @@ import simplejson as json
 from six import string_types
 
 from pisa import ureg
-
+from pisa.utils.log import logging, set_verbosity
 
 __all__ = [
     'JSON_EXTS',
@@ -535,8 +535,9 @@ def test_to_json_from_json():
     finally:
         rmtree(temp_dir)
 
-    sys.stdout.write('<< PASS : test_to_json_from_json >>\n')
+    logging.info('<< PASS : test_to_json_from_json >>')
 
 
 if __name__ == '__main__':
+    set_verbosity(1)
     test_to_json_from_json()

--- a/pisa/utils/matrix.py
+++ b/pisa/utils/matrix.py
@@ -5,6 +5,8 @@ Utilities for performing some not-so-common matrix tasks.
 import numpy as np
 import scipy.linalg as lin
 
+from pisa.utils.log import logging, set_verbosity
+
 __all__ = [
     'is_psd',
     'fronebius_nearest_psd',
@@ -133,13 +135,13 @@ def test_matrix_random():
     """Unit test producing a number of random matrices and checking if the
     approximated matrix is indeed PSD.
     """
-    import sys
     m_test = np.array([[1, -1], [2, 4]])
     test_frob_psd(m_test)
     for i in range(100):
         m_test = np.random.randn(3, 3)
         test_frob_psd(m_test)
-    sys.stdout.write('<< PASS : test_matrix_random >>\n')
+    logging.info('<< PASS : test_matrix_random >>')
 
 if __name__ == '__main__':
+    set_verbosity(1)
     test_matrix_random()

--- a/pisa/utils/matrix.py
+++ b/pisa/utils/matrix.py
@@ -129,16 +129,17 @@ def test_frob_psd(A):
     assert is_psd_after, "did not produce PSD matrix"
     assert np.isclose(xdist, actual_dist), "actual distance differs from expectation"
 
-if __name__ == '__main__':
+def test_matrix_random():
+    """Unit test producing a number of random matrices and checking if the
+    approximated matrix is indeed PSD.
+    """
+    import sys
     m_test = np.array([[1, -1], [2, 4]])
     test_frob_psd(m_test)
-    print('matrix before:')
-    print(m_test)
-    print('matrix after:')
-    print(fronebius_nearest_psd(m_test))
-    print('The result matrix is psd and the Frobenius norm matches the expectation!')
-    print('testing random matrices...')
     for i in range(100):
         m_test = np.random.randn(3, 3)
         test_frob_psd(m_test)
-    print('Test passed!')
+    sys.stdout.write('<< PASS : test_matrix_random >>\n')
+
+if __name__ == '__main__':
+    test_matrix_random()


### PR DESCRIPTION
Should fix issue #570 .

It was possible in `binning` to give an index that is actually invalid. This would cause an obscure error later on when only the length of the now string index is checked. Even more obscure, if the given index string happened to have the same length as the binning has dimensions ("pid"), it would pass the length check and break later with an even more obscure error. 

Let's raise an exception instead with a helpful list of the keys that would have been valid.