### PR TITLE
allow (all?) scalar types in vectorizer; black

### DIFF
--- a/pisa/utils/vectorizer.py
+++ b/pisa/utils/vectorizer.py
@@ -18,24 +18,26 @@ from pisa.utils.numba_tools import WHERE
 
 
 __all__ = [
-    'mul',
-    'imul',
-    'imul_and_scale',
-    'itruediv',
-    'assign',
-    'pow',
-    'sqrt',
-    'replace_where_counts_gt',
+    "mul",
+    "imul",
+    "imul_and_scale",
+    "itruediv",
+    "assign",
+    "pow",
+    "sqrt",
+    "replace_where_counts_gt",
 ]
 
-__version__ = '0.2'
-__author__ = 'Philipp Eller (pde3@psu.edu)'
+__version__ = "0.2"
+__author__ = "Philipp Eller (pde3@psu.edu)"
 
 
-FX = 'f4' if FTYPE == np.float32 else 'f8'
+FX = "f4" if FTYPE == np.float32 else "f8"
+SCALAR_TYPES = "f4 f8 u1 u2 u4 u8 uintc uintp i2 i4 i8 intc intp".split()
 
 
-#------------------------------------------------------------------------------#
+# ---------------------------------------------------------------------------- #
+
 
 def scale(vals, scale, out):
     """Multiply .. ::
@@ -43,14 +45,19 @@ def scale(vals, scale, out):
         out[:] = vals[:] * scale
 
     """
-    scale_gufunc(vals.get(WHERE), FTYPE(scale), out=out.get(WHERE))
+    scale_gufunc(vals.get(WHERE), scale, out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}, {FX}[:])'], '(), () -> ()', target=TARGET)
+
+@guvectorize(
+    [f"({FX}[:], {st}, {FX}[:])" for st in SCALAR_TYPES], "(), () -> ()", target=TARGET
+)
 def scale_gufunc(vals, scale, out):
     out[0] = vals[0] * scale
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def mul(vals0, vals1, out):
     """Multiply .. ::
@@ -61,11 +68,14 @@ def mul(vals0, vals1, out):
     mul_gufunc(vals0.get(WHERE), vals1.get(WHERE), out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}[:], {FX}[:])'], '(), () -> ()', target=TARGET)
+
+@guvectorize([f"({FX}[:], {FX}[:], {FX}[:])"], "(), () -> ()", target=TARGET)
 def mul_gufunc(vals0, vals1, out):
     out[0] = vals0[0] * vals1[0]
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def imul(vals, out):
     """Multiply augmented assignment of two arrays .. ::
@@ -76,11 +86,14 @@ def imul(vals, out):
     imul_gufunc(vals.get(WHERE), out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}[:])'], '() -> ()', target=TARGET)
+
+@guvectorize([f"({FX}[:], {FX}[:])"], "() -> ()", target=TARGET)
 def imul_gufunc(vals, out):
     out[0] *= vals[0]
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def imul_and_scale(vals, scale, out):
     """Multiply and scale augmented assignment .. ::
@@ -88,12 +101,16 @@ def imul_and_scale(vals, scale, out):
         out[:] *= vals[:] * scale
 
     """
-    imul_and_scale_gufunc(vals.get(WHERE), FTYPE(scale), out=out.get(WHERE))
+    imul_and_scale_gufunc(vals.get(WHERE), scale, out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}, {FX}[:])'], '(), () -> ()', target=TARGET)
+
+@guvectorize(
+    [f"({FX}[:], {st}, {FX}[:])" for st in SCALAR_TYPES], "(), () -> ()", target=TARGET
+)
 def imul_and_scale_gufunc(vals, scale, out):
     out[0] *= vals[0] * scale
+
 
 def test_imul_and_scale():
     """Unit tests for function ``imul_and_scale``"""
@@ -103,13 +120,15 @@ def test_imul_and_scale():
     out = np.ones_like(a)
     out = SmartArray(out)
 
-    imul_and_scale(vals=a, scale=10., out=out)
+    imul_and_scale(vals=a, scale=10.0, out=out)
 
-    assert np.allclose(out.get('host'), np.linspace(0, 10, 1000, dtype=FTYPE))
+    assert np.allclose(out.get("host"), np.linspace(0, 10, 1000, dtype=FTYPE))
 
-    logging.info('<< PASS : test_multiply_and_scale >>')
+    logging.info("<< PASS : test_multiply_and_scale >>")
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def itruediv(vals, out):
     """Divide augmented assignment .. ::
@@ -121,14 +140,17 @@ def itruediv(vals, out):
     itruediv_gufunc(vals.get(WHERE), out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}[:])'], '() -> ()', target=TARGET)
+
+@guvectorize([f"({FX}[:], {FX}[:])"], "() -> ()", target=TARGET)
 def itruediv_gufunc(vals, out):
-    if vals[0] == 0.:
-        out[0] = 0.
+    if vals[0] == 0.0:
+        out[0] = 0.0
     else:
         out[0] /= vals[0]
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def assign(vals, out):  # pylint: disable=redefined-builtin
     """Assign array vals from another array .. ::
@@ -139,11 +161,14 @@ def assign(vals, out):  # pylint: disable=redefined-builtin
     assign_gufunc(vals.get(WHERE), out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}[:])'], '() -> ()', target=TARGET)
+
+@guvectorize([f"({FX}[:], {FX}[:])"], "() -> ()", target=TARGET)
 def assign_gufunc(vals, out):
     out[0] = vals[0]
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def pow(vals, pwr, out):  # pylint: disable=redefined-builtin
     """Raise vals to pwr.. ::
@@ -151,14 +176,19 @@ def pow(vals, pwr, out):  # pylint: disable=redefined-builtin
         out[:] = vals[:]**pwr
 
     """
-    pow_gufunc(vals.get(WHERE), FTYPE(pwr), out=out.get(WHERE))
+    pow_gufunc(vals.get(WHERE), pwr, out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}, {FX}[:])'], '(), () -> ()', target=TARGET)
-def pow_gufunc(vals, pwr, out):
-    out[0] = vals[0]**pwr
 
-#------------------------------------------------------------------------------#
+@guvectorize(
+    [f"({FX}[:], {st}, {FX}[:])" for st in SCALAR_TYPES], "(), () -> ()", target=TARGET
+)
+def pow_gufunc(vals, pwr, out):
+    out[0] = vals[0] ** pwr
+
+
+# ---------------------------------------------------------------------------- #
+
 
 def sqrt(vals, out):
     """Square root of vals .. ::
@@ -169,30 +199,41 @@ def sqrt(vals, out):
     sqrt_gufunc(vals.get(WHERE), out=out.get(WHERE))
     out.mark_changed(WHERE)
 
-@guvectorize([f'({FX}[:], {FX}[:])'], '() -> ()', target=TARGET)
+
+@guvectorize([f"({FX}[:], {FX}[:])"], "() -> ()", target=TARGET)
 def sqrt_gufunc(vals, out):
     out[0] = math.sqrt(vals[0])
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
+
 
 def replace_where_counts_gt(vals, counts, min_count, out):
-    """Replace `out[i]` with `vals[i]` where `counts[i]` > `min_count`"""
+    """Replace `out[i]` with `vals[i]` where `counts[i]` > `min_count` .. ::
+
+        mask = counts[:] > min_count
+        out[mask] = vals[mask]
+
+    """
     replace_where_counts_gt_gufunc(
-        counts.get(WHERE),
-        min_count,
-        vals.get(WHERE),
-        out=out.get(WHERE),
+        vals.get(WHERE), counts.get(WHERE), min_count, out=out.get(WHERE)
     )
 
-@guvectorize([f'({FX}[:], {FX}[:], i4, {FX}[:])'], '(), (), () -> ()', target=TARGET)
+
+@guvectorize(
+    [f"({FX}[:], {FX}[:], {st}, {FX}[:])" for st in SCALAR_TYPES],
+    "(), (), () -> ()",
+    target=TARGET,
+)
 def replace_where_counts_gt_gufunc(vals, counts, min_count, out):
     """Replace `out[i]` with `vals[i]` where `counts[i]` > `min_count`"""
     if counts[0] > min_count:
         out[0] = vals[0]
 
-#------------------------------------------------------------------------------#
+
+# ---------------------------------------------------------------------------- #
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     set_verbosity(1)
     test_imul_and_scale()


### PR DESCRIPTION
* Create signatures for each known scalar type to avoid explicit casting to one or another in the python code
  * This allows e.g. `pwr` and `min_counts` (in `pow` and `replace_where_counts_gt`, respectively) to be either float, int, or uint, and of any supported width
* Bugfix: order of args to `replace_where_counts_gt_gufunc` was incorrect