### PR TITLE
Scaled poisson fluctuation

### DIFF
--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -943,9 +943,9 @@ class Map(object):
             'gauss+poisson'. Strings are case-insensitive and whitespace is
             removed.
             The 'scaled_poisson' method implements a Scaled Poisson Process, which is 
-            a better approximation to the true distribution when the bin counts are 
-            the result of a Poisson process with weighted events[1] (as is the case in MC
-            maps). The fluctuated maps are guaranteed to have the same mean and standard
+            a better approximation than a normal distribution to the true distribution 
+            of bin counts that are the result of a Poisson process with weighted events[1].
+            The fluctuated maps are guaranteed to have the same mean and standard
             deviation as the original map.
 
         random_state : None or type accepted by utils.random_numbers.get_random_state

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -973,14 +973,14 @@ class Map(object):
                 nan_at = np.isnan(orig_hist)
                 valid_mask = ~nan_at
 
-                hist_vals = np.empty_like(orig_hist, dtype=np.float64)
+                hist_vals = np.empty_like(orig_hist)
                 hist_vals[valid_mask] = poisson.rvs(
                     orig_hist[valid_mask],
                     random_state=random_state
                 )
                 hist_vals[nan_at] = np.nan
 
-                error_vals = np.empty_like(orig_hist, dtype=np.float64)
+                error_vals = np.empty_like(orig_hist)
                 error_vals[valid_mask] = np.sqrt(orig_hist[valid_mask])
                 error_vals[nan_at] = np.nan
             return {'hist': unp.uarray(hist_vals, error_vals)}
@@ -1010,7 +1010,7 @@ class Map(object):
                     scale_factor = variance_valid/orig_hist[valid_mask]
                 poisson_lambda = orig_hist[valid_mask]/scale_factor
 
-                hist_vals = np.empty_like(orig_hist, dtype=np.float64)
+                hist_vals = np.empty_like(orig_hist)
                 hist_vals[valid_mask] = poisson.rvs(
                     poisson_lambda,
                     random_state=random_state

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -966,6 +966,14 @@ class Map(object):
                 nan_at = np.isnan(orig_hist)
                 zero_at = orig_hist == 0.
                 valid_mask = ~nan_at
+                if np.any(sigma[valid_mask & ~zero_at] == 0.):
+                    logging.warn(
+                        "Some bins have non-zero counts but no assiciated error! "
+                        "Errors will be set to their Poisson expectation now. "
+                        "To avoid this warning, call `set_poisson_errors()` on the "
+                        "map or set non-zero errors manually."
+                    )
+                    sigma[valid_mask] = np.sqrt(orig_hist[valid_mask])
                 variance_valid = sigma[valid_mask]**2
 
                 if np.allclose(variance_valid, orig_hist[valid_mask], **ALLCLOSE_KW):


### PR DESCRIPTION
The current implementation of the `poisson` fluctuation method cannot be used to fluctuate MC events in a meaningful way. Furthermore, the fluctuation does not have the standard deviation that is stored in the Map, and instead fudges the standard deviation in a way the user might not expect. 

This PR implements the Scaled Poisson Process derived in [Bohm & Zech 2018](https://arxiv.org/abs/1309.1287) and applies it when the stored standard deviations in a map are not sqrt(N). This process ensures that the mean and standard deviation are correctly observed and is a reasonable approximation from the fluctuation that can be expected from a Compound Poisson Process that produces our MC expectations. 

If a map has errors of sqrt(N), as is the case after `set_poisson_errors()` has been called, there is no difference between the new and old behavior.

A warning is issued when a map has no associated errors, as the behavior is technically undefined. In that case, we fall back to the old behavior, but warn the user about what is happening.