### PR TITLE
fix the distribution_maker get_outputs function to properly handle more than 2 pipelines

### DIFF
--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -203,7 +203,8 @@ class DistributionMaker(object):
         outputs = [pipeline.get_outputs(**kwargs) for pipeline in self] # pylint: disable=redefined-outer-name
         if return_sum:
             if len(outputs) > 1:
-                outputs = reduce(lambda x, y: sum(x) + sum(y), outputs)
+                outputs = sum([sum(x) for x in outputs])
+                #outputs = reduce(lambda x, y: sum(x) + sum(y), outputs)
             else:
                 outputs = sum(sum(outputs))
             outputs.name = sum_map_name

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from collections import OrderedDict
 from collections.abc import Mapping
-from functools import reduce
 import inspect
 from itertools import product
 import os

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -204,7 +204,7 @@ class DistributionMaker(object):
         if return_sum:
             if len(outputs) > 1:
                 outputs = sum([sum(x) for x in outputs])
-                #outputs = reduce(lambda x, y: sum(x) + sum(y), outputs)
+
             else:
                 outputs = sum(sum(outputs))
             outputs.name = sum_map_name


### PR DESCRIPTION
This is a simple fix on the `get_outputs` function of distribution maker, in the case where we want to return the sum of all maps. 

previous behavior (using the python `reduce`) didn't work once you added a third pipeline, because the sum of two MapSet is a Map, and not a MapSet.