### PR TITLE
Make earth absorption stage compatible with GPU target

### DIFF
--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -202,6 +202,7 @@ class pi_earth_absorption(PiStage):
                                                              container['nubar'],
                                                              container['true_energy'].get(WHERE)
                                                             )
+            container['xsection'].mark_changed(WHERE)
             calculate_survivalprob(container['rho_int'].get(WHERE),
                                    container['xsection'].get(WHERE),
                                    out=container['survival_prob'].get(WHERE)

--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -184,6 +184,7 @@ class pi_earth_absorption(PiStage):
                                      container['densities'].get(WHERE),
                                      out=container['rho_int'].get(WHERE)
                                     )
+            container['rho_int'].mark_changed(WHERE)
         # don't forget to un-link everything again
         self.data.unlink_containers()
 

--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -153,6 +153,10 @@ class pi_earth_absorption(PiStage):
             container['densities'] = self.layers.density.reshape((container.size, self.layers.max_layers))
             container['distances'] = self.layers.distance.reshape((container.size, self.layers.max_layers))
             container['rho_int'] = np.empty((container.size), dtype=FTYPE)
+            
+            container['densities'].mark_changed(WHERE)
+            container['distances'].mark_changed(WHERE)
+            container['rho_int'].mark_changed(WHERE)
         # don't forget to un-link everything again
         self.data.unlink_containers()
 

--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -24,6 +24,21 @@ from pisa.utils.numba_tools import WHERE
 from pisa.utils import vectorizer
 from pisa.utils.resources import find_resource
 
+__author__ = 'A. Trettin'
+
+__license__ = '''Copyright (c) 2020, The IceCube Collaboration
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.'''
 
 FLAV_BAR_STR_MAPPING = {
     (0, -1): "e_bar",

--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -249,7 +249,7 @@ def calculate_integrated_rho(layer_dists, layer_densities, out):
     out[0] = 0
     for i in range(len(layer_dists)):
         out[0] += layer_dists[i]*layer_densities[i]
-    out[0] *= 1e5
+    out[0] *= 1e5  # distances are converted from km to cm
 
 @guvectorize(signatures, '(),()->()', target=TARGET)
 def calculate_survivalprob(int_rho, xsection, out):


### PR DESCRIPTION
This PR addresses issue #596 . The unsupported functions `np.dot` and `np.exp` are replaced so that both 'cpu' and 'gpu' targets work with this stage. I checked that both import without errors and give the same result. 