### PR TITLE
Attempt to fix issue #608,  parsing non-param args in sensible way

### DIFF
--- a/pisa/utils/config_parser.py
+++ b/pisa/utils/config_parser.py
@@ -747,12 +747,15 @@ def parse_pipeline_config(config):
             # this by its full name and try to interpret and instantiate a
             # Python object using the string
             else:
-                try:
-                    value = parse_quantity(value)
-                    value = value.nominal_value * value.units
-                except ValueError:
-                    value = parse_string_literal(value)
-                service_kwargs[fullname] = value
+                if re.search(r'[^a-z_]units\.[a-z]+', value, flags=re.IGNORECASE):
+                    try:
+                        new_value = parse_quantity(value)
+                        new_value = new_value.nominal_value * new_value.units
+                    except ValueError:
+                        new_value = parse_string_literal(value)
+                else:
+                    new_value = parse_string_literal(value)
+                service_kwargs[fullname] = new_value
 
         # If no params actually specified in config, remove 'params' from the
         # service's keyword args


### PR DESCRIPTION
Attempt to fix issue #608 :

If `[^a-z]units\.[a-z]+` regex is found in a value being parsed, try to parse as a Pint quantity (possibly with errors via uncertainties). If that fails, or if that string wasn't found, parse as a literal value (i.e., NOT as a Pint quantity).