### PR TITLE
Osc layers

### DIFF
--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -126,8 +126,8 @@ def extCalcLayers(cz,
             calculate_small_root = (coszen < coszen_limit) * (coszen_limit <= coszen_limit[idx])
             calculate_large_root = (coszen_limit>coszen)
 
-            small_roots = - r_detector * coszen.astype(FTYPE) * calculate_small_root.astype(FTYPE) - np.sqrt(r_detector**2 * coszen.astype(FTYPE)**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_small_root, out=np.zeros_like(radii))
-            large_roots = - r_detector * coszen.astype(FTYPE) * calculate_large_root.astype(FTYPE) + np.sqrt(r_detector**2 * coszen.astype(FTYPE)**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_large_root, out=np.zeros_like(radii))
+            small_roots = - r_detector * coszen * calculate_small_root.astype(FTYPE) - np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_small_root, out=np.zeros_like(radii))
+            large_roots = - r_detector * coszen * calculate_large_root.astype(FTYPE) + np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_large_root, out=np.zeros_like(radii))
 
             # Remove the negative root numbers, and the initial zeros distances
             small_roots = small_roots[small_roots>0]

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -126,6 +126,11 @@ def extCalcLayers(cz,
             calculate_small_root = (coszen < coszen_limit) * (coszen_limit <= coszen_limit[idx])
             calculate_large_root = (coszen_limit>coszen)
 
+            logging.info('r_detector: {}'.format(type(r_detector)))
+            logging.info('coszen: {}'.format(type(coszen)))
+            logging.info('radii: {}'.format(type(radii)))
+            logging.info('calculate: {}'.format(type(calculate_small_root)))
+
             small_roots = - r_detector * coszen * calculate_small_root - np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_small_root, out=np.zeros_like(radii))
             large_roots = - r_detector * coszen * calculate_large_root + np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_large_root, out=np.zeros_like(radii))
 

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -126,10 +126,10 @@ def extCalcLayers(cz,
             calculate_small_root = (coszen < coszen_limit) * (coszen_limit <= coszen_limit[idx])
             calculate_large_root = (coszen_limit>coszen)
 
-            logging.info('r_detector: {}'.format(type(r_detector)))
-            logging.info('coszen: {}'.format(type(coszen)))
-            logging.info('radii: {}'.format(type(radii)))
-            logging.info('calculate: {}'.format(type(calculate_small_root)))
+            print('r_detector: {}'.format(type(r_detector)))
+            print('coszen: {}'.format(type(coszen)))
+            print('radii: {}'.format(type(radii)))
+            print('calculate: {}'.format(type(calculate_small_root)))
 
             small_roots = - r_detector * coszen * calculate_small_root - np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_small_root, out=np.zeros_like(radii))
             large_roots = - r_detector * coszen * calculate_large_root + np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_large_root, out=np.zeros_like(radii))

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -83,8 +83,8 @@ def extCalcLayers(cz,
     # which is later reshaped into containers of size (# of cz values, max_layers)
     # in the pi_prob3 module
 
-    densities = np.zeros((len(cz), max_layers))
-    distances = np.zeros((len(cz), max_layers))
+    densities = np.zeros((len(cz), max_layers), dtype=FTYPE)
+    distances = np.zeros((len(cz), max_layers), dtype=FTYPE)
     number_of_layers = np.zeros(len(cz))
 
     # Loop over all CZ values
@@ -131,7 +131,7 @@ def extCalcLayers(cz,
 
             # Remove the negative root numbers, and the initial zeros distances
             small_roots = small_roots[small_roots>0]
-            small_roots = np.concatenate((np.array([0.], dtype=FTYPE), small_roots))
+            small_roots = np.concatenate((np.array([0.], dtype=FTYPE), small_roots.astype(FTYPE)))
 
             # Reverse the order of the large roots
             # That should give the segment distances from the furthest layer to
@@ -481,7 +481,7 @@ def test_layers_2():
     logging.info('Detector radius = %s km'%layer.r_detector)
     logging.info('Neutrino production height = %s km'%layer.prop_height)
     layer.computeMinLengthToLayers()
-    ref_cz_crit = np.array([1., 1., -0.4461133826191877, -0.8375825182106081, -0.9814881717430358,  -1.])
+    ref_cz_crit = np.array([1., 1., -0.4461133826191877, -0.8375825182106081, -0.9814881717430358,  -1.], dtype=FTYPE)
     logging.debug('Asserting Critical coszen values...')
     assert np.allclose(layer.coszen_limit, ref_cz_crit, **ALLCLOSE_KW), f'test:\n{layer.coszen_limit}\n!= ref:\n{ref_cz_crit}'
 
@@ -546,7 +546,7 @@ def test_layers_3():
     # cz = 0 (horizontal path)
     # cz = -0.4461133826191877 (tangent to the first inner layer of PREM4)
     # cz = -1 (path below the detector)
-    cz_values = np.array([1., 0, -0.4461133826191877, -1.])
+    cz_values = np.array([1., 0, -0.4461133826191877, -1.], dtype=FTYPE)
 
     # Run the layer calculation
     layer.calcLayers(cz=cz_values)

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -126,13 +126,8 @@ def extCalcLayers(cz,
             calculate_small_root = (coszen < coszen_limit) * (coszen_limit <= coszen_limit[idx])
             calculate_large_root = (coszen_limit>coszen)
 
-            print('r_detector: {}'.format(type(r_detector)))
-            print('coszen: {}'.format(type(coszen)))
-            print('radii: {}'.format(type(radii)))
-            print('calculate: {}'.format(type(calculate_small_root)))
-
-            small_roots = - r_detector * coszen * calculate_small_root - np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_small_root, out=np.zeros_like(radii))
-            large_roots = - r_detector * coszen * calculate_large_root + np.sqrt(r_detector**2 * coszen**2 - r_detector**2 + radii**2) #, where=calculate_large_root, out=np.zeros_like(radii))
+            small_roots = - r_detector * coszen.astype(FTYPE) * calculate_small_root.astype(FTYPE) - np.sqrt(r_detector**2 * coszen.astype(FTYPE)**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_small_root, out=np.zeros_like(radii))
+            large_roots = - r_detector * coszen.astype(FTYPE) * calculate_large_root.astype(FTYPE) + np.sqrt(r_detector**2 * coszen.astype(FTYPE)**2 - r_detector**2 + radii.astype(FTYPE)**2) #, where=calculate_large_root, out=np.zeros_like(radii))
 
             # Remove the negative root numbers, and the initial zeros distances
             small_roots = small_roots[small_roots>0]

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -95,14 +95,14 @@ def extCalcLayers(cz,
         # Deal with paths that do not have tangeants
         #
         if coszen>=coszen_limit[I]: 
-            cumulative_distances = -r_detector*coszen + np.sqrt(r_detector**2.*coszen**2. -r_detector**2. + radii[:I]**2.)
+            cumulative_distances = -r_detector * coszen + np.sqrt(r_detector**2. * coszen**2. - r_detector**2. + radii[:I]**2.)
             # a bit of flippy business is done here to order terms
             # such that numpy diff can work
-            segments_lengths = np.diff(np.concatenate([np.array([0.]), cumulative_distances[::-1]]))
+            segments_lengths = np.diff(np.concatenate((np.array([0.], dtype=FTYPE), cumulative_distances[::-1])))
             segments_lengths = segments_lengths[::-1]
-            segments_lengths = np.concatenate([segments_lengths, np.zeros(radii.shape[0]-I)])
-            rhos*=(segments_lengths>0.)
-            density = np.concatenate([rhos, np.zeros(radii.shape[0]-I)])
+            segments_lengths = np.concatenate((segments_lengths, np.zeros(radii.shape[0] - I, dtype=FTYPE)))
+            rhos *= (segments_lengths > 0.)
+            density = np.concatenate((rhos, np.zeros(radii.shape[0] - I, dtype=FTYPE)))
 
             #print('diff with total path', np.sum(segment_distances)-path_len) # CHECKED
 
@@ -114,8 +114,8 @@ def extCalcLayers(cz,
             calculate_small_root = (coszen<coszen_limit)*(coszen_limit<=coszen_limit[I])
             calculate_large_root = (coszen_limit>coszen)
 
-            small_roots = -r_detector*coszen*calculate_small_root - np.sqrt(r_detector**2*coszen**2 - r_detector**2+ radii**2, where=calculate_small_root, out=np.zeros_like(radii))
-            large_roots = -r_detector*coszen*calculate_large_root + np.sqrt(r_detector**2*coszen**2 - r_detector**2+ radii**2, where=calculate_large_root, out=np.zeros_like(radii))
+            small_roots = -r_detector*coszen*calculate_small_root - np.sqrt(r_detector**2*coszen**2 - r_detector**2+ radii**2) #, where=calculate_small_root, out=np.zeros_like(radii))
+            large_roots = -r_detector*coszen*calculate_large_root + np.sqrt(r_detector**2*coszen**2 - r_detector**2+ radii**2) #, where=calculate_large_root, out=np.zeros_like(radii))
 
             #
             # concatenate large and small roots together
@@ -129,7 +129,7 @@ def extCalcLayers(cz,
             # layer (N-1), then layer(N-2)...). This layer ends with
             # the two large roots of the layers above the detector height
             #
-            full_distances = np.concatenate([small_roots, np.flip(large_roots)])
+            full_distances = np.concatenate((small_roots, large_roots[::-1]))
 
             # The above vector gives the cumulative distance travelled
             # after passing each layer, starting from the detector and 
@@ -150,13 +150,13 @@ def extCalcLayers(cz,
             #
             # arange the densities to match the segment array structure
             #
-            density = np.concatenate([rhos,np.flip(rhos)])
+            density = np.concatenate((rhos, rhos[::-1]))
             density*=(segments_lengths>0.)
             #
             # To respect the order at which layers are crossed, all these array must be flipped
             #
-            segments_lengths = np.flip(segments_lengths)
-            density = np.flip(density)
+            segments_lengths = segments_lengths[::-1]
+            density = density[::-1]
 
         n_layers = np.sum(segments_lengths>0.,dtype=np.float64)
 
@@ -223,8 +223,8 @@ class Layers(object):
             self.max_layers = 2 * n_prem + 1
 
             # Add an external layer corresponding to the atmosphere / production boundary
-            self.radii = np.concatenate([np.array([r_earth+prop_height]), self.radii])
-            self.rhos  = np.concatenate([np.zeros(1, dtype=FTYPE), self.rhos])
+            self.radii = np.concatenate((np.array([r_earth+prop_height]), self.radii))
+            self.rhos  = np.concatenate((np.zeros(1, dtype=FTYPE), self.rhos))
 
         else :
             self.using_earth_model = False

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -98,8 +98,8 @@ def extCalcLayers(cz,
             cumulative_distances = -r_detector*coszen + np.sqrt(r_detector**2.*coszen**2. -r_detector**2. + radii[:I]**2.)
             # a bit of flippy business is done here to order terms
             # such that numpy diff can work
-            segments_lengths= np.flip(np.diff(np.concatenate([np.array([0.]), np.flip(cumulative_distances)])))
-
+            segments_lengths = np.diff(np.concatenate([np.array([0.]), cumulative_distances[::-1]]))
+            segments_lengths = segments_lengths[::-1]
             segments_lengths = np.concatenate([segments_lengths, np.zeros(radii.shape[0]-I)])
             rhos*=(segments_lengths>0.)
             density = np.concatenate([rhos, np.zeros(radii.shape[0]-I)])
@@ -393,7 +393,7 @@ class Layers(object):
 
 
 
-def test_layers():
+def test_layers_1():
 
     logging.info('Test layers calculation:')
     layer = Layers('osc/PREM_4layer.dat')
@@ -413,7 +413,7 @@ def test_layers():
 
     logging.info('<< PASS : test_Layers >>')
 
-def test_layers_II():
+def test_layers_2():
     '''
     Validate the total distance travered,
     the number of layers crossed and the distance
@@ -461,6 +461,7 @@ def test_layers_II():
     logging.info('Neutrino production height = %s km'%layer.prop_height)
     layer.computeMinLengthToLayers()
     ref_cz_crit = np.array([1., 1., -0.4461133826191877, -0.8375825182106081, -0.9814881717430358,  -1.])
+    logging.debug('Asserting Critical coszen values...')
     assert np.allclose(layer.coszen_limit, ref_cz_crit, **ALLCLOSE_KW), f'test:\n{layer.coszen_limit}\n!= ref:\n{ref_cz_crit}'
 
     #
@@ -481,6 +482,7 @@ def test_layers_II():
                               3376.716060094899, 7343.854310588515,12567.773643090592, 12761.])
     layer.calcPathLength(input_cz)
     computed_length = layer._distance
+    logging.debug('Testing full path in vacuum calculations...')
     assert np.allclose(computed_length, correct_length, **ALLCLOSE_KW), f'test:\n{computed_length}\n!= ref:\n{correct_length}'
 
     #
@@ -497,8 +499,9 @@ def test_layers_II():
     #
     # sin(alpha) = sin(pi-theta)*D /Rp
     #
-
+    logging.debug('Testing Earth layer segments and density computations...')
 
 if __name__ == '__main__':
     set_verbosity(3)
-    test_layers_II()
+    test_layers_1()
+    test_layers_2()

--- a/pisa/stages/utils/pi_adhoc_sys.py
+++ b/pisa/stages/utils/pi_adhoc_sys.py
@@ -1,0 +1,105 @@
+"""
+Stage to implement an ad-hoc systematic that corrects the discrepancy between data and
+MC in one particular variable. This can be used to check how large the impact of such a
+hypothetical systematic would be on the physics parameters of an analysis.
+"""
+
+from __future__ import absolute_import, print_function, division
+
+import numpy as np
+
+from pisa import FTYPE
+from pisa.core.pi_stage import PiStage
+from pisa.utils.profiler import profile
+from pisa.utils import vectorizer
+from pisa.utils.log import logging
+from pisa.utils.resources import find_resource
+from pisa.utils.jsons import from_json
+from pisa.core.binning import OneDimBinning, MultiDimBinning
+
+class pi_adhoc_sys(PiStage):  # pylint: disable=invalid-name
+    """
+    Stage to re-weight events according to factors derived from post-fit data/MC
+    comparisons. The comparisons are produced somewhere externally and stored as a JSON
+    which encodes the binning that was used to make the comparison and the resulting
+    scaling factors.
+    
+    Parameters
+    ----------
+    
+    variable_name : str
+        Name of the variable to correct data/MC agreement for. The variable must be
+        loaded in the data loading stage and it must be present in the loaded JSON file.
+    
+    scale_file : str
+        Path to the file which contains the binning and the scale factors. The JSON
+        file must contain a dictionary in which, for each variable, a 1D binning and
+        an array of factors. This file is produced externally from PISA.
+    """
+    def __init__(
+        self,
+        data=None,
+        params=None,
+        variable_name=None,
+        scale_file=None,
+        input_names=None,
+        output_names=None,
+        debug_mode=None,
+        error_method=None,
+        input_specs=None,
+        calc_specs=None,
+        output_specs=None,
+    ):
+        
+        expected_params = ()
+        input_names = ()
+        output_names = ()
+
+        # what are the keys used from the inputs during apply
+        input_apply_keys = ("weights")
+        output_apply_keys = ("weights")
+        # no calc_keys here, we do only manual conversion
+        output_calc_keys = ()
+        
+        # init base class
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            error_method=error_method,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            output_calc_keys=output_calc_keys,
+            input_apply_keys=input_apply_keys,
+            output_apply_keys=output_apply_keys,
+        )
+
+        assert self.input_mode == "events"
+        assert self.output_mode == "events"
+        
+        self.scale_file = scale_file
+        self.variable = variable_name
+
+    def setup_function(self):
+        scale_file = find_resource(self.scale_file)
+        logging.info("Loading scaling factors from : %s", scale_file)
+        
+        scaling_dict = from_json(scale_file)
+        scale_binning = MultiDimBinning(**scaling_dict[self.variable]["binning"])
+        
+        scale_factors = np.array(scaling_dict[self.variable]["scales"], dtype=FTYPE)
+        logging.info(f"Binning for ad-hoc systematic: \n {str(scale_binning)}")
+        logging.info(f"scaling factors of ad-hoc systematic:\n {str(scale_factors)}")
+        self.data.data_specs = scale_binning
+        for container in self.data:
+            container["adhoc_scale_factors"] = scale_factors
+            container.binned_to_array("adhoc_scale_factors")
+    
+    def apply_function(self):
+        for container in self.data:
+            vectorizer.imul(vals=container["adhoc_scale_factors"], out=container["weights"])
+


### PR DESCRIPTION
Looking a bit more closely into this stage, I noticed that path lengths seem to be calculated in a way that is not very straightforward to understand. This PR tries to simplify the computations made in layers.py to make them easier to understand. I also added a few assert statements to prevent one from defining unphysical detector locations and radii definitions.

Note that the only thing that has changed computationaly is the way the full path length, as computed in extCalcLayers and calcPathLength. The logic and steps behind the multi layer calculations should probably also be looked at, though it will have to be in a later PR :) 