### PR TITLE
correcting flaws in the likelihood test script

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -851,7 +851,7 @@ class Analysis(object):
             if blind:
                 msg = ''
             else:
-                msg = ' ' + optimize_result.message
+                msg = ' ' + str(optimize_result.message)
             raise ValueError('Optimization failed.' + msg)
 
         return fit_info

--- a/pisa/stages/data/pi_simple_signal.py
+++ b/pisa/stages/data/pi_simple_signal.py
@@ -208,6 +208,8 @@ class pi_simple_signal(PiStage):
                 reweighting/=np.sum(reweighting)
                 reweighting*=(self.nsig/self.stats_factor)
 
+                reweighting[np.isnan(reweighting)] = 0.
+
                 #
                 # New MC errors = MCweights squared
                 #

--- a/pisa/stages/data/pi_simple_signal.py
+++ b/pisa/stages/data/pi_simple_signal.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, print_function, division
 __author__ = "Etienne Bourbeau (etienne.bourbeau@icecube.wisc.edu)"
 
 import numpy as np
-
+from pisa import FTYPE
 from pisa.core.container import Container
 from pisa.core.pi_stage import PiStage
 
@@ -98,11 +98,11 @@ class pi_simple_signal(PiStage):
         # figure out how many signal and background events to create
         #
         n_data_events = int(self.params.n_events_data.value.m)
-        stats_factor = float(self.params.stats_factor.value.m)
+        self.stats_factor = float(self.params.stats_factor.value.m)
         signal_fraction = float(self.params.signal_fraction.value.m)
 
         # Number of simulated MC events
-        self.n_mc = int(n_data_events*stats_factor)
+        self.n_mc = int(n_data_events*self.stats_factor)
         # Number of signal MC events
         self.nsig = int(self.n_mc*signal_fraction)
         self.nbkg = self.n_mc-self.nsig                     # Number of bkg MC events
@@ -115,19 +115,34 @@ class pi_simple_signal(PiStage):
         #
         signal_container = Container('signal')
         signal_container.data_specs = 'events'
-        # Populate the signal physics quantity
-        signal_container.add_array_data('stuff', np.zeros(self.nsig))
-        # Populate its MC weight
-        signal_container.add_array_data('weights', np.ones(self.nsig)*1./stats_factor)
+        # Populate the signal physics quantity over a uniform range
+        signal_initial  = np.random.uniform(low=self.params.bkg_min.value.m,
+                                               high=self.params.bkg_max.value.m,
+                                               size=self.nsig)
+
+        signal_container.add_array_data('stuff', signal_initial)
+        # Populate its MC weight by equal constant factors
+        signal_container.add_array_data('weights', np.ones(self.nsig, dtype=FTYPE)*1./self.stats_factor)
         # Populate the error on those weights
-        signal_container.add_array_data('errors',(np.ones(self.nsig)*1./stats_factor)**2. )
-        # Add empty bin_indices array (used in generalized poisson llh)
-        signal_container.add_array_data('bin_indices', np.ones(self.nsig)*-1)
-        # Add bin indices mask (used in generalized poisson llh)
+        signal_container.add_array_data('errors',(np.ones(self.nsig, dtype=FTYPE)*1./self.stats_factor)**2. )
+
+        #
+        # Compute the bin indices associated with each event
+        #
+        sig_indices = lookup_indices(sample=[signal_container['stuff']], binning=self.output_specs)
+        sig_indices = sig_indices.get('host')
+        signal_container.add_array_data('bin_indices', sig_indices)
+
+        #
+        # Compute an associated bin mask for each output bin
+        #
         for bin_i in range(self.output_specs.tot_num_bins):
-            signal_container.add_array_data(key='bin_{}_mask'.format(
-                bin_i), data=np.zeros(self.nsig, dtype=bool))
+            sig_bin_mask = sig_indices == bin_i
+            signal_container.add_array_data(key='bin_{}_mask'.format(bin_i), data=sig_bin_mask)
+
+        #
         # Add container to the data
+        #
         self.data.add_container(signal_container)
 
         #
@@ -137,23 +152,27 @@ class pi_simple_signal(PiStage):
 
             bkg_container = Container('background')
             bkg_container.data_specs = 'events'
-            bkg_container.add_array_data('stuff', np.zeros(self.nbkg))
-            bkg_container.add_array_data('weights', np.ones(self.nbkg)*1./stats_factor)
-            bkg_container.add_array_data('errors',(np.ones(self.nbkg)*1./stats_factor)**2. )
-            bkg_container.add_array_data('bin_indices', np.ones(self.nbkg)*-1)
+            # Create a set of background events
+            initial_bkg_events = np.random.uniform(low=self.params.bkg_min.value.m, high=self.params.bkg_max.value.m, size=self.nbkg)
+            bkg_container.add_array_data('stuff', initial_bkg_events)
+            # create their associated weights
+            bkg_container.add_array_data('weights', np.ones(self.nbkg)*1./self.stats_factor)
+            bkg_container.add_array_data('errors',(np.ones(self.nbkg)*1./self.stats_factor)**2. )
+            # compute their bin indices
+            bkg_indices = lookup_indices(sample=[bkg_container['stuff']], binning=self.output_specs)
+            bkg_indices = bkg_indices.get('host')
+            bkg_container.add_array_data('bin_indices', bkg_indices)
             # Add bin indices mask (used in generalized poisson llh)
             for bin_i in range(self.output_specs.tot_num_bins):
-                bkg_container.add_array_data(key='bin_{}_mask'.format(
-                    bin_i), data=np.zeros(self.nbkg, dtype=bool))
+                bkg_bin_mask = bkg_indices==bin_i
+                bkg_container.add_array_data(key='bin_{}_mask'.format(bin_i), data=bkg_bin_mask)
 
             self.data.add_container(bkg_container)
 
-        #
-        # Bin the weights according to the output specs binning
-        # Provide a binning if non is specified
-        # if self.output_specs is None:
-        #    self.output_specs = MultiDimBinning([OneDimBinning(name='stuff', bin_edges=np.linspace(0.,40.,21))])
 
+        #
+        # Add the binned counterpart of each events container
+        #
         for container in self.data:
             container.array_to_binned('weights', binning=self.output_specs, averaged=False)
             container.array_to_binned('errors', binning=self.output_specs, averaged=False)
@@ -161,8 +180,14 @@ class pi_simple_signal(PiStage):
 
     def apply_function(self):
         '''
-        This is where we actually inject a gaussian signal and a
-        flat background according to the parameters
+        This is where we re-weight the signal container
+        based on a model gaussian with tunable parameters
+        mu and sigma.
+
+        The background is left untouched in this step.
+
+        A possible upgrade to this function would be to make a 
+        small background re-weighting
 
         This function will be called at every iteration of the minimizer
         '''
@@ -171,74 +196,31 @@ class pi_simple_signal(PiStage):
         # Make sure we are in events mode
         #
         self.data.data_specs = 'events'
+        from scipy.stats import norm
 
         for container in self.data:
 
             if container.name == 'signal':
                 #
-                # First, generate the signal
+                # Signal is a gaussian pdf, weighted to account for the MC statistics and the signal fraction
                 #
-                signal = np.random.normal(
-                    loc=self.params['mu'].value.m, scale=self.params['sigma'].value.m, size=self.nsig)
-                container['stuff'] = signal
-
-            elif container.name == 'background':
-                #
-                # Then the background
-                #
-                background = np.random.uniform(low=self.params.bkg_min.value.m,
-                                               high=self.params.bkg_max.value.m,
-                                               size=self.nbkg)
-
-                container['stuff'] = background
-
-            #
-            # Recompute the bin indices associated with each event
-            #
-            new_array = lookup_indices(
-                sample=[container['stuff']], binning=self.output_specs)
-            new_array = new_array.get('host')
-            container["bin_indices"] = new_array
-
-            for bin_i in range(self.output_specs.tot_num_bins):
-                container['bin_{}_mask'.format(bin_i)] = new_array == bin_i
-
-        #
-        # Re-bin the data
-        #
-        for container in self.data:
-            container.array_to_binned(
-                'weights', binning=self.output_specs, averaged=False)
-            container.array_to_binned(
-                'errors', binning=self.output_specs, averaged=False)
-
-
-            #
-            #  Recalculate the number of MC events per bin, if the array already exists
-            #
-            if "n_mc_events" in container.binned_data.keys():
-
-                self.data.data_specs = 'events'
-                nevents_sim = np.zeros(self.output_specs.tot_num_bins)
-
-                for index in range(self.output_specs.tot_num_bins):
-                    index_mask = container['bin_{}_mask'.format(index)].get('host')
-                    current_weights = container['weights'].get('host')[index_mask]
-                    n_weights = current_weights.shape[0]
-
-                    # Number of MC events in each bin
-                    nevents_sim[index] = n_weights
-
-                self.data.data_specs = self.output_specs
-                np.copyto(src=nevents_sim,
-                          dst=container["n_mc_events"].get('host'))
+                reweighting = norm.pdf(container['stuff'].get('host'), loc=self.params['mu'].value.m, scale=self.params['sigma'].value.m)/self.stats_factor
+                reweighting/=np.sum(reweighting)
+                reweighting*=(self.nsig/self.stats_factor)
 
                 #
-                # Step 2: Re-calculate the mean adjustment for each container
+                # New MC errors = MCweights squared
                 #
-                mean_number_of_mc_events = np.mean(nevents_sim)
-                if mean_number_of_mc_events < 1.0:
-                    mean_adjustment = -(1.0-mean_number_of_mc_events) + 1.e-3
-                else:
-                    mean_adjustment = 0.0
-                container.scalar_data['mean_adjustment']=mean_adjustment
+                new_errors = reweighting**2.
+
+                #
+                # Replace the weight information in the signal container
+                #
+                np.copyto(src=reweighting, dst=container["weights"].get('host'))
+                np.copyto(src=new_errors, dst=container['errors'].get('host'))
+                container['weights'].mark_changed()
+                container['errors'].mark_changed()
+
+                # Re-bin the events weight into new histograms
+                container.array_to_binned('weights', binning=self.output_specs, averaged=False)
+                container.array_to_binned('errors', binning=self.output_specs, averaged=False)

--- a/pisa/stages/data/super_simple_pipeline.cfg
+++ b/pisa/stages/data/super_simple_pipeline.cfg
@@ -32,7 +32,9 @@ input_specs = None
 calc_specs = None
 output_specs = super_simple_binning
 
-
+# Arguments to turn pseudo weight and mean adjustment on and off
+with_pseudo_weight = False
+with_mean_adjust = False
 
 [pipeline]
 

--- a/pisa/stages/likelihood/pi_generalized_llh_params.py
+++ b/pisa/stages/likelihood/pi_generalized_llh_params.py
@@ -59,7 +59,7 @@ from pisa.utils.profiler import profile, line_profile
 from pisa.utils.log import set_verbosity, Levels
 #set_verbosity(Levels.DEBUG)
 
-PSEUDO_WEIGHT = 0.001
+#PSEUDO_WEIGHT = 0.001
 
 
 class pi_generalized_llh_params(PiStage):
@@ -80,6 +80,9 @@ class pi_generalized_llh_params(PiStage):
 		input_specs=None,
 		calc_specs=None,
 		output_specs=None,
+
+		with_pseudo_weight=None, # turn pseudo-weight on or off
+		with_mean_adjust=None,   # turn mean adjustment on or off
 		):
 		#
 		# A bunch of options we don't need
@@ -96,6 +99,9 @@ class pi_generalized_llh_params(PiStage):
 		output_apply_keys = ('weights', 'errors', 'llh_alphas', 'hs_scales',
 							 'llh_betas', 'n_mc_events', 'old_sum')
 
+		self.with_mean_adjust = with_mean_adjust
+		self.with_pseudo_weight = with_pseudo_weight
+
 		# init base class
 		super(pi_generalized_llh_params, self).__init__(data=data,
 												 params=params,
@@ -109,6 +115,7 @@ class pi_generalized_llh_params(PiStage):
 												 input_apply_keys=input_apply_keys,
 												 output_apply_keys=output_apply_keys,
 												 output_calc_keys=output_calc_keys,
+
 												 )
 
 	def setup_function(self):
@@ -146,19 +153,19 @@ class pi_generalized_llh_params(PiStage):
 				nevents_sim[index] = np.sum(index_mask)
 
 			self.data.data_specs = self.output_specs
-			np.copyto(src=nevents_sim,
-					  dst=container["n_mc_events"].get('host'))
+			np.copyto(src=nevents_sim, dst=container["n_mc_events"].get('host'))
 			container['n_mc_events'].mark_changed()
 
 			#
 			# Step 2: Calculate the mean adjustment for each container
 			#
-			mean_number_of_mc_events = np.mean(nevents_sim)
-			if mean_number_of_mc_events < 1.0:
-				mean_adjustment = -(1.0-mean_number_of_mc_events) + 1.e-3
-			else:
-				mean_adjustment = 0.0
-			container.add_scalar_data(key='mean_adjustment', data=mean_adjustment)
+			if self.with_mean_adjust:
+				mean_number_of_mc_events = np.mean(nevents_sim)
+				if mean_number_of_mc_events < 1.0:
+					mean_adjustment = -(1.0-mean_number_of_mc_events) + 1.e-3
+				else:
+					mean_adjustment = 0.0
+				container.add_scalar_data(key='mean_adjustment', data=mean_adjustment)
 
 
 			#
@@ -168,6 +175,7 @@ class pi_generalized_llh_params(PiStage):
 			#
 			if 'hs_scales' not in container.keys():
 				container['hs_scales'] =  np.empty((container.size), dtype=FTYPE)
+			if 'errors' not in container.keys():
 				container['errors'] = np.empty((container.size), dtype=FTYPE)
 
 
@@ -195,9 +203,19 @@ class pi_generalized_llh_params(PiStage):
 			#         in empty bins
 
 			# for this part we are in events mode
-			# Find the minimum weight of an entire MC set
-			pseudo_weight = 0.001
-			container.add_scalar_data(key='pseudo_weight', data=pseudo_weight)
+			# Find the mean weight of an entire MC set
+			#
+			# We only consider the first 90 percentiles of the weight
+			# values, to avoid the high extreme weights that muongun
+			# often gives 
+			#
+			all_container_weights = container['weights'].get('host')
+
+			if self.with_pseudo_weight:
+				percentile90 = np.percentile(all_container_weights,90)
+				pseudo_weight = np.mean(all_container_weights[all_container_weights<=percentile90])
+				#pseudo_weight = np.amin(all_container_weights[all_container_weights>0])
+				container.add_scalar_data(key='pseudo_weight', data=pseudo_weight)
 
 			old_weight_sum = np.zeros(N_bins)
 			new_weight_sum = np.zeros(N_bins)
@@ -207,15 +225,16 @@ class pi_generalized_llh_params(PiStage):
 			#
 			# Load the pseudo_weight and mean displacement values
 			#
-			mean_adjustment = container.scalar_data['mean_adjustment']
-			pseudo_weight = container.scalar_data['pseudo_weight']
+			if self.with_mean_adjust:
+				mean_adjustment = container.scalar_data['mean_adjustment']
+
 
 			for index in range(N_bins):
 
 				index_mask = container['bin_{}_mask'.format(index)].get('host')
 				if 'kfold_mask' in container:
 					index_mask*=container['kfold_mask'].get('host')
-				current_weights = container['weights'].get('host')[index_mask]
+				current_weights = all_container_weights[index_mask]
 
 				old_weight_sum[index] += np.sum(current_weights)
 
@@ -226,7 +245,7 @@ class pi_generalized_llh_params(PiStage):
 				# Bins with no mc event in all set will be ignore in the likelihood later
 				#
 				# make the whole bin treatment here
-				if n_weights <= 0:
+				if n_weights <= 0 and self.with_pseudo_weight:
 					current_weights = np.array([pseudo_weight])
 					n_weights = 1
 
@@ -252,8 +271,12 @@ class pi_generalized_llh_params(PiStage):
 				# of beta = 1.0, which mimicks a narrow PDF
 				# close to 0.0 
 				beta = np.divide(mean_w, var_z, out=np.ones(1), where=var_z!=0)
-				trad_alpha = np.divide(mean_w**2, var_z, out=np.ones(1)*PSEUDO_WEIGHT, where=var_z!=0)
-				alpha = (n_weights + mean_adjustment)*trad_alpha
+				trad_alpha = np.divide(mean_w**2, var_z, out=np.ones(1)*np.NaN, where=var_z!=0)
+
+				if self.with_mean_adjust:
+					alpha = (n_weights + mean_adjustment)*trad_alpha
+				else:
+					alpha = n_weights*trad_alpha
 
 				alphas_vector[index] = alpha
 				betas_vector[index] = beta
@@ -262,12 +285,17 @@ class pi_generalized_llh_params(PiStage):
 			self.data.data_specs = self.output_specs
 			np.copyto(src=alphas_vector, dst=container['llh_alphas'].get('host'))
 			np.copyto(src=betas_vector, dst=container['llh_betas'].get('host'))
-			np.copyto(src=new_weight_sum, dst=container['weights'].get('host'))
+
+			#only change the weights if they were modified
+			if self.with_pseudo_weight or self.with_mean_adjust:
+				np.copyto(src=new_weight_sum, dst=container['weights'].get('host'))
+				container['weights'].mark_changed()
+		
 			np.copyto(src=old_weight_sum, dst=container['old_sum'].get('host'))
 			container['llh_alphas'].mark_changed()
 			container['llh_betas'].mark_changed()
 			container['old_sum'].mark_changed()
-			container['weights'].mark_changed()
+
 
 
 

--- a/pisa/utils/stats.py
+++ b/pisa/utils/stats.py
@@ -610,20 +610,15 @@ def generalized_poisson_llh(actual_values, expected_values=None, empty_bins=None
         assert np.all(weight_sum >= 0), 'ERROR: negative weights detected'
 
         #
-        # If the expected MC count is high, compute a normal poisson probability
-        # 
-        if weight_sum.sum()>100:
+        # If the number of MC events is high, compute a normal poisson probability
+        #
+        n_mc_events = np.array([m.hist.flatten()[bin_i] for m in expected_values['n_mc_events'].maps])
+        if np.all(n_mc_events>100):
 
             logP = data_count*np.log(weight_sum.sum())-weight_sum.sum()-(data_count*np.log(data_count)-data_count)
             llh_per_bin[bin_i] = logP
             
-            #alphas = np.array([m.hist.flatten()[bin_i] for m in expected_values['llh_alphas'].maps])
-            #betas  = np.array([m.hist.flatten()[bin_i] for m in expected_values['llh_betas'].maps])
-            #mask = np.isfinite(alphas)*np.isfinite(betas)
-            #llh_per_bin[bin_i] = approximate_poisson_normal(data_count=data_count, alphas=alphas[mask], betas=betas[mask])
-            
         else:
-            
             from pisa.utils.llh_defs.poisson import fast_pgmix
 
             alphas = np.array([m.hist.flatten()[bin_i] for m in expected_values['llh_alphas'].maps])

--- a/pisa_tests/likelihoods_1D_test.py
+++ b/pisa_tests/likelihoods_1D_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Test script to compare the performances of
 the generalized poisson llh with the other 
@@ -14,9 +15,22 @@ __author__ = "Etienne Bourbeau (etienne.bourbeau@icecube.wisc.edu)"
 #
 import os
 import pickle
-import collections
+from collections import OrderedDict
 import copy
 import numpy as np
+
+#
+# Font stuff
+#
+import matplotlib as mpl 
+mpl.use('agg')
+from matplotlib import rcParams
+FONTSIZE=20
+rcParams['font.family'] = 'serif'
+rcParams['font.size'] = 20
+mpl.rc('text', usetex=True)
+#mpl.rcParams['text.latex.preamble']=[r"\usepackage{amsmath}"]
+
 
 
 #
@@ -33,7 +47,7 @@ from pisa.analysis.analysis import Analysis
 from pisa.utils.log import logging
 from pisa.utils.profiler import line_profile
 from pisa.utils.log import set_verbosity, Levels
-set_verbosity(Levels.TRACE)
+#set_verbosity(Levels.TRACE)
 
 ##################################################################################
 
@@ -41,8 +55,31 @@ STANDARD_CONFIG = os.environ['PISA'] + \
     '/pisa/stages/data/super_simple_pipeline.cfg'
 TRUE_MU = 20.
 TRUE_SIGMA = 3.1
-NBINS = 51
+NBINS = 31
 
+#
+# Define formatting properties for all metrics
+#
+import seaborn as sns
+COLORS = sns.color_palette("muted", 8)
+
+LIKELIHOOD_FORMATTING = OrderedDict()
+LIKELIHOOD_FORMATTING['llh'] = {'label':r'Poisson llh',
+                                'marker':'s',
+                                'color': COLORS[0]}
+
+LIKELIHOOD_FORMATTING['mcllh_eff'] = {'label':r'Effective llh',
+                                'color': COLORS[1]}
+
+LIKELIHOOD_FORMATTING['mcllh_mean'] = {'label':r'Mean llh',
+                                       'color': COLORS[2],
+                                       'linestyle': '--'}
+
+LIKELIHOOD_FORMATTING['generalized_poisson_llh'] = {'label':r'Generalized llh',
+                                       'color': COLORS[7]}
+
+LIKELIHOOD_FORMATTING['mod_chi2'] = {'label':r'Mod. $\chi^{2}$',
+                                       'color': COLORS[3]}
 ################################################################################
 
 
@@ -60,8 +97,7 @@ class ToyMCllhParam:
         self.nbackground_low = 0.       # lowest value the background can take
         self.nbackground_high = 40.     # highest value the background can take
         self.stats_factor = 1.          # Statistical factor for the MC
-        # Value of what we consider an infinite MC stats factor
-        self.infinite_stats = 10000
+
 
         #
         # Binning
@@ -100,6 +136,7 @@ def create_pseudo_data(toymc_params, seed=None):
         np.random.seed(seed)
 
     binning = toymc_params.binning
+
     #
     # Gaussian signal peak
     #
@@ -112,11 +149,10 @@ def create_pseudo_data(toymc_params, seed=None):
     background = np.random.uniform(
         high=toymc_params.nbackground_high, low=toymc_params.nbackground_low, size=toymc_params.nbkg)
     total_data = np.concatenate([signal, background])
-    counts_data, _ = np.histogram(total_data, bins=binning.bin_edges.magnitude)
+    counts_data, _ = np.histogram(total_data, bins=binning.bin_edges[0].magnitude)
 
     # Convert data histogram into a pisa map
-    data_map = Map(name='total', binning=MultiDimBinning(
-        [binning]), hist=counts_data)
+    data_map = Map(name='total', binning=binning, hist=counts_data)
 
     # Set the errors as the sqrt of the counts
     data_map.set_errors(error_hist=np.sqrt(counts_data))
@@ -126,7 +162,7 @@ def create_pseudo_data(toymc_params, seed=None):
     return data_as_mapset
 
 
-def create_mc_template(toymc_params, config_file=None, seed=None):
+def create_mc_template(toymc_params, config_file=None, seed=None, keep_same_weight=True):
     '''
     Create MC template out of a pisa pipeline
     '''
@@ -134,6 +170,18 @@ def create_mc_template(toymc_params, config_file=None, seed=None):
         np.random.seed(seed)
 
     Config = parse_pipeline_config(config_file)
+
+    # Change binning
+    Config[('data','pi_simple_signal')]['output_specs'] = toymc_params.binning
+    Config[('likelihood','pi_generalized_llh_params')]['output_specs'] = toymc_params.binning
+
+    # If keep_same_weight is True, turn off the mean adjust and pseudo weight of pi_generalized_llh
+    if keep_same_weight:
+        Config[('likelihood','pi_generalized_llh_params')]['with_mean_adjust'] = False
+        Config[('likelihood','pi_generalized_llh_params')]['with_pseudo_weight'] = False
+    else:
+        Config[('likelihood','pi_generalized_llh_params')]['with_mean_adjust'] = True
+        Config[('likelihood','pi_generalized_llh_params')]['with_pseudo_weight'] = True
 
     new_n_events_data = Param(
         name='n_events_data', value=toymc_params.n_data, prior=None, range=None, is_fixed=True)
@@ -157,7 +205,7 @@ def create_mc_template(toymc_params, config_file=None, seed=None):
 
 ##################################################################################
 
-def run_llh_scans(metrics=[], mc_template=None, data_mapset=None, results=None):
+def run_llh_scans(metrics=[], mc_params=None, config_file=None, data_mapset=None, mc_seed=None, results=None):
     '''
     Perform Likelihood scans fover a range of injected mu values
 
@@ -169,32 +217,39 @@ def run_llh_scans(metrics=[], mc_template=None, data_mapset=None, results=None):
 
     '''
 
-    assert isinstance(results, (dict, collections.OrderedDict)
+    assert isinstance(results, (dict, OrderedDict)
                       ), 'ERROR: results must be a dict'
 
     assert 'toymc_params' in results.keys(), 'ERROR: missing toymc_params'
 
-    toymc_params = results['toymc_params']
+
     for metric in metrics:
         if metric not in results.keys():
-            results[metric] = collections.OrderedDict()
-        results[metric]['llh_scan'] = collections.OrderedDict()
+            results[metric] = OrderedDict()
+        results[metric]['llh_scan'] = OrderedDict()
+
+    #
+    # Create the mc template
+    #
+    mc_template = create_mc_template(mc_params, config_file=config_file, seed=mc_seed)
 
     #
     # Collect the llh value at the Truth
     #
     for metric in metrics:
+        print(metric)
 
         mc_template.params['mu'].value = toymc_params.true_mu
 
+        new_MC = mc_template.get_outputs(return_sum=True, force_standard_output=False)
+
         if metric == 'generalized_poisson_llh':
-            new_MC = mc_template.get_outputs(
-                return_sum=False, force_standard_output=False)[0]
             llhval = data_mapset.maps[0].metric_total(new_MC, metric=metric, metric_kwargs={
                                                       'empty_bins': mc_template.empty_bin_indices})
             logging.trace('empty_bins: ', mc_template.empty_bin_indices)
+
         else:
-            new_MC = mc_template.get_outputs(return_sum=True)
+            new_MC = new_MC['old_sum']
             llhval = data_mapset.metric_total(new_MC, metric=metric)
 
         results[metric]['llh_scan']['llh_at_truth'] = llhval
@@ -211,20 +266,18 @@ def run_llh_scans(metrics=[], mc_template=None, data_mapset=None, results=None):
             # Recompute the MC template with a new value of the mu parameter
             #
             mc_template.params['mu'].value = tested_mu
+            new_MC = mc_template.get_outputs(return_sum=True, force_standard_output=False)
 
             if metric == 'generalized_poisson_llh':
-                new_MC = mc_template.get_outputs(
-                    return_sum=False, force_standard_output=False)[0]
                 llhval = data_mapset.maps[0].metric_total(new_MC, metric=metric, metric_kwargs={
                                                           'empty_bins': mc_template.empty_bin_indices})
             else:
-                new_MC = mc_template.get_outputs(return_sum=True)
+                new_MC = new_MC['old_sum']
                 llhval = data_mapset.metric_total(new_MC, metric=metric)
 
-            if 'chi2' in metric:
-                results[metric]['llh_scan']['scan_values'].append((llhval-results[metric]['llh_scan']['llh_at_truth']))
-            else:
-                results[metric]['llh_scan']['scan_values'].append(-2*(llhval-results[metric]['llh_scan']['llh_at_truth']))
+
+            results[metric]['llh_scan']['scan_values'].append(llhval)
+
 
     return results
 
@@ -234,24 +287,28 @@ def plot_llh_scans(metrics=[], results=None, interactive=False, output_pdf=None)
     Plot Likelihood scans
     '''
 
-    fig, ax = plt.subplots(figsize=(9, 9))
+    fig, ax = plt.subplots(figsize=(7, 7))
     n = 0
     for llh_name in metrics:
 
         llhvals = results[llh_name]['llh_scan']['scan_values']
         tested_mu = results[llh_name]['llh_scan']['tested_mu']
 
-        if llh_name == 'mcllh_eff':
-            ax.plot(tested_mu, llhvals, 'o', color=COLORS[n], label=llh_name)
+        if 'chi2' in llh_name:
+            TS = llhvals-np.amin(llhvals)
         else:
-            ax.plot(tested_mu, llhvals, linewidth=2,
-                    color=COLORS[n], label=llh_name)
+            TS = -2*(llhvals-np.amax(llhvals))
+
+        ax.plot(tested_mu, TS, **LIKELIHOOD_FORMATTING[llh_name])
         n += 1
     ax.set_xlabel(r'injected $\mu$')
-    ax.set_ylabel(r'-2$\log[L_{\mu}/L_{o}]$')
-    ax.set_ylim([0., 5000])
-    ax.set_title('Likelihood scans over mu')
+    ax.set_ylabel(r'Test Statistic(-2$\ln[L_{\mu}/L_{o}]$ or $\chi^{2}$)')
+    ax.set_ylim([-10., 500])
+    ax.plot([15.,25.],[0.,0.],'k')
+    ax.set_title('MC factor = {}'.format(results['toymc_params'].stats_factor))
+    #ax.set_title('Likelihood scans over mu')
     ax.legend()
+    fig.tight_layout()
 
     if interactive:
         plt.show()
@@ -269,8 +326,8 @@ def plot_llh_scans(metrics=[], results=None, interactive=False, output_pdf=None)
 #@line_profile
 def run_coverage_test(n_trials=100,
                       toymc_params=None,
-                      mc_template=None,
-                      mc_infinite_stats=None,
+                      mc_seed = None,
+                      config_file=None,
                       metrics=None,
                       results=None,
                       output_stem='coverage_test'):
@@ -288,8 +345,6 @@ def run_coverage_test(n_trials=100,
                   of the experiment like signal_fraction and
                   stats_factor)
 
-    mc_template: DistributionMaker 
-                 (MC template made with the level of stats you test)
 
     mc_infinite_Stats: DistributionMaker 
                        (MC template made with an ideal level
@@ -298,15 +353,15 @@ def run_coverage_test(n_trials=100,
     '''
     import time
 
-    assert isinstance(results, (dict, collections.OrderedDict)), 'ERROR: results must be a dict'
+    assert isinstance(results, (dict, OrderedDict)), 'ERROR: results must be a dict'
     assert isinstance(metrics, list), 'ERROR: must specify metrics as a list'
     assert 'toymc_params' in results.keys(), 'ERROR: missing toymc_params'
 
-    toymc_params = results['toymc_params']
 
+    results['toymc_params'] = toymc_params
     for metric in metrics:
         if metric not in results.keys():
-            results[metric] = collections.OrderedDict()
+            results[metric] = OrderedDict()
         results[metric]['coverage'] = []
 
     #
@@ -328,6 +383,19 @@ def run_coverage_test(n_trials=100,
                                       }
                           }
 
+
+    #
+    # Create the mc template
+    #
+    mc_template = create_mc_template(toymc_params, config_file=config_file, seed=mc_seed)
+
+    #
+    # Create a pseudo-infinite statistics template
+    #
+    infinite_toymc_params = copy.deepcopy(toymc_params)
+    infinite_toymc_params.stats_factor = 100.
+    mc_template_pseudo_infinite = create_mc_template(infinite_toymc_params, config_file=config_file, seed=mc_seed)
+
     #
     # Start pseudo trials
     #
@@ -338,7 +406,7 @@ def run_coverage_test(n_trials=100,
 
         else:
 
-            logging.trace('minimizing: ', metric)
+            logging.debug('minimizing: ', metric)
             to = time.time()
 
             trial_i = 0
@@ -350,22 +418,21 @@ def run_coverage_test(n_trials=100,
                 #
                 # Create a pseudo-dataset
                 #
-                data_trial = create_pseudo_data(
-                    toymc_params=toymc_params, seed=None)
+                data_trial = create_pseudo_data(toymc_params=toymc_params, seed=None)
 
                 #
                 # Compute the truth llh value of this pseudo experiment
                 # truth - if the truth comes from infinite stats MC
                 #
                 if metric == 'generalized_poisson_llh':
-                    mc = mc_infinite_stats.get_outputs(
-                        return_sum=False, force_standard_output=False)[0]
+                    mc = mc_template_pseudo_infinite.get_outputs(return_sum=False, force_standard_output=False)[0]
+
                     llhval_true = data_trial.maps[0].metric_total(mc, 
                                                                   metric=metric, 
                                                                   metric_kwargs={
-                                                                  'empty_bins': mc_infinite_stats.empty_bin_indices})
+                                                                  'empty_bins': mc_template_pseudo_infinite.empty_bin_indices})
                 else:
-                    mc = mc_infinite_stats.get_outputs(return_sum=True)
+                    mc = mc_template_pseudo_infinite.get_outputs(return_sum=True)
                     llhval_true = data_trial.metric_total(mc, metric=metric)
 
                 experiment_result['llh_infinite_stats'] = llhval_true
@@ -388,31 +455,32 @@ def run_coverage_test(n_trials=100,
 
                 experiment_result['llh_lowstats'] = llhval
 
-                #
-                # minimized llh (high stats)
-                #
-                logging.trace('\nhigh stats fit:\n')
-                ana = Analysis()
-                result_pseudo_truth, _ = ana.fit_hypo(data_trial,
-                                                      mc_infinite_stats,
-                                                      metric=metric,
-                                                      minimizer_settings=minimizer_settings,
-                                                      hypo_param_selections=None,
-                                                      check_octant=False,
-                                                      fit_octants_separately=False,
-                                                      )
-                #except:
-                #    logging.trace('Failed Fit')
-                #    failed_fits += 1
-                #    continue
-                experiment_result['infinite_stats_opt'] = {'metric_val': result_pseudo_truth['metric_val'],
-                                                           'best_fit_param': result_pseudo_truth['params']['mu']}
+                # #
+                # # minimized llh (high stats)
+                # #
+                # logging.debug('\nhigh stats fit:\n')
+                # ana = Analysis()
+                # result_pseudo_truth, _ = ana.fit_hypo(data_trial,
+                #                                       mc_infinite_stats,
+                #                                       metric=metric,
+                #                                       minimizer_settings=minimizer_settings,
+                #                                       hypo_param_selections=None,
+                #                                       check_octant=False,
+                #                                       fit_octants_separately=False,
+                #                                       )
+                # #except:
+                # #    logging.trace('Failed Fit')
+                # #    failed_fits += 1
+                # #    continue
+                # experiment_result['infinite_stats_opt'] = {'metric_val': result_pseudo_truth['metric_val'],
+                #                                            'best_fit_param': result_pseudo_truth['params']['mu']}
 
                 #
                 # minimized llh (low stats)
                 #
-                logging.trace('\nlow stats fit:\n')
+                logging.debug('\nlow stats fit:\n')
                 ana = Analysis()
+
                 try:
                     result_lowstats, _ = ana.fit_hypo(data_trial,
                                                       mc_template,
@@ -423,7 +491,7 @@ def run_coverage_test(n_trials=100,
                                                       fit_octants_separately=False,
                                                       )
                 except:
-                    logging.trace('Failed Fit')
+                    logging.debug('Failed Fit')
                     failed_fits += 1
                     continue
 
@@ -437,10 +505,10 @@ def run_coverage_test(n_trials=100,
                 raise Exception('ERROR: no fit managed to converge after {} attempst'.format(failed_fits))
 
             t1 = time.time()
-            logging.trace("Time for ", n_trials, " minimizations: ", t1-to, " s")
-            logging.trace("Saving to file...")
+            logging.debug("Time for ", n_trials, " minimizations: ", t1-to, " s")
+            logging.debug("Saving to file...")
             pickle.dump(results[metric]['coverage'], open(filename, 'wb'))
-            logging.trace("Saved.")
+            logging.debug("Saved.")
 
     return results
 
@@ -497,9 +565,9 @@ def plot_coverage_test(output_pdf=None,
         for pseudo_exp in indata:
 
             val_low = pseudo_exp['lowstats_opt']['best_fit_param'].value.m
-            val_high = pseudo_exp['infinite_stats_opt']['best_fit_param'].value.m
+            #val_high = pseudo_exp['infinite_stats_opt']['best_fit_param'].value.m
             llh_optimized_low = pseudo_exp['lowstats_opt']['metric_val']
-            llh_optimized_high = pseudo_exp['infinite_stats_opt']['metric_val']
+            #llh_optimized_high = pseudo_exp['infinite_stats_opt']['metric_val']
             llh_truth_low = pseudo_exp['llh_lowstats']
             llh_truth_high = pseudo_exp['llh_infinite_stats']
 
@@ -507,38 +575,38 @@ def plot_coverage_test(output_pdf=None,
             # check that all elements of the comparison are finite
             #
             good_trial = np.isfinite(val_low)
-            good_trial *= np.isfinite(val_high)
+            #good_trial *= np.isfinite(val_high)
             good_trial *= np.isfinite(llh_optimized_low)
-            good_trial *= np.isfinite(llh_optimized_high)
+            #good_trial *= np.isfinite(llh_optimized_high)
             good_trial *= np.isfinite(llh_truth_low)
             good_trial *= np.isfinite(llh_truth_high)
 
             if good_trial:
 
                 container_val_lowstat.append(val_low)
-                container_val_highstat.append(val_high)
+                #container_val_highstat.append(val_high)
                 container_ts_truth_high.append(llh_truth_high)
                 container_ts_truth_low.append(llh_truth_low)
 
                 ts_low = -2*(llh_optimized_low-llh_truth_low)
-                ts_high = -2*(llh_optimized_high-llh_truth_high)
+                #ts_high = -2*(llh_optimized_high-llh_truth_high)
 
                 # We take the absolute value here because we want to know how far
                 # we are from the truth, and we can optimize to llh values above and below the truth
                 container_ts_lowstat.append(np.abs(ts_low))
-                container_ts_highstat.append(np.abs(ts_high))
+                #container_ts_highstat.append(np.abs(ts_high))
 
-                llh_bias.append(-2*(ts_low-ts_high))
+                #llh_bias.append(-2*(ts_low-ts_high))
                 param_bias.append((val_low-val_truth)/val_truth)
 
             else:
                 continue
 
-        fig = Figure(nx=2, ny=3, figsize=(20, 30), title=llh_name)
+        fig = Figure(nx=2, ny=3, figsize=(20, 30), title=LIKELIHOOD_FORMATTING[llh_name]['label'])
         fig.get_ax(x=0, y=0).set_title(
             'ts Distribution - 10000 x more MC than data')
-        fig.get_ax(x=0, y=0).hist(container_ts_highstat, bins=ts_binning,
-                                  histtype='step', linewidth=2., color='r', label='ts distribution')
+        #fig.get_ax(x=0, y=0).hist(container_ts_highstat, bins=ts_binning,
+        #                         histtype='step', linewidth=2., color='r', label='ts distribution')
         fig.get_ax(x=0, y=0).hist(sample_chi2_distrib, bins=ts_binning,
                                   histtype='step', linewidth=2., color='k', label=r'$\chi^{2}_{dof=1}$')
         fig.get_ax(x=0, y=0).set_xlabel(
@@ -557,8 +625,8 @@ def plot_coverage_test(output_pdf=None,
 
         fig.get_ax(x=0, y=1).set_title(
             'Fitted Parameter Value - 10000 x MC vs. data')
-        fig.get_ax(x=1, y=0).hist(container_val_highstat, bins=20, histtype='step',
-                                  linewidth=2., color='r', label=r'Best-fit $\mu_{opt}$')
+        #fig.get_ax(x=1, y=0).hist(container_val_highstat, bins=20, histtype='step',
+        #                          linewidth=2., color='r', label=r'Best-fit $\mu_{opt}$')
         fig.get_ax(x=1, y=0).axvline(x=20, linewidth=2,
                                      color='k', ls='--', label=r'Truth ($\mu = 20$')
         fig.get_ax(x=1, y=0).set_xlabel(r'value')
@@ -574,7 +642,7 @@ def plot_coverage_test(output_pdf=None,
         fig.get_ax(x=1, y=1).legend()
 
         fig.get_ax(x=0, y=2).set_title('LLH Bias')
-        fig.get_ax(x=0, y=2).hist(llh_bias, bins=20)
+        #fig.get_ax(x=0, y=2).hist(llh_bias, bins=20)
         fig.get_ax(x=0, y=2).set_xlabel(
             r'llh Bias $-2\left (ts_{low\ stats} -ts_{high\ stats} \right )$')
         fig.get_ax(x=0, y=2).axvline(x=0., linewidth=2, color='k', ls='--')
@@ -594,11 +662,15 @@ def plot_coverage_test(output_pdf=None,
 
         for percent_coverage in coverage_x:
             chi2_ts_value = chi2.ppf(percent_coverage, df=1)
-            actual_coverage = sum(np.array(
-                container_ts_lowstat) <= chi2_ts_value)/float(len(container_ts_lowstat))
+            actual_coverage = sum(np.array(container_ts_lowstat) <= chi2_ts_value)
+
+            if len(container_ts_lowstat)>0:
+                actual_coverage/=float(len(container_ts_lowstat))
+            else:
+                actual_coverage=0.
             coverage_y.append(actual_coverage)
 
-        coverage_fig.get_ax().plot(coverage_x, coverage_y, label=llh_name)
+        coverage_fig.get_ax().plot(coverage_x, coverage_y, **LIKELIHOOD_FORMATTING[llh_name])
 
     coverage_fig.get_ax().set_xlabel('Expected Wilks coverage')
     coverage_fig.get_ax().set_ylabel('Actual Coverage (low statistics')
@@ -607,64 +679,99 @@ def plot_coverage_test(output_pdf=None,
 
 
 def plot_data_and_mc(data_map=None,
-                     mc_map=None,
-                     mc_params=None,
-                     mc_map_pseudo_infinite=None, 
-                     mc_params_pseudo_infinite=None,
+                     config_file=STANDARD_CONFIG,
                      toymc_params=None,
-                     toymc_params_pseudo_infinite=None,
                      interactive=False,
+                     mc_seed=None,
                      output_pdf=None):
     '''
     plot the data, and the mc sets overlaid on top
     '''
-    X = toymc_params.binning.midpoints
+    # ===============================================================
+    #
+    # Generate MC template using a pisa pipeline
+    #
+    # We first need to override the parameter values contained in the config file
+    # before instantiating the pipeline
+    print('Create the first template')
+    mc_template = create_mc_template(toymc_params, config_file=config_file, seed=mc_seed)
+    mc_map = sum(mc_template.get_outputs(return_sum=True, force_standard_output=False)['old_sum']) #old_sum = map without pseudo weights
+    mc_generalized_map = sum(mc_template.get_outputs(return_sum=True, force_standard_output=False)['weights']) #weights = map with pseudo-weight
+    mc_params = mc_template.params
+
+
+    # =================================================================
+    #
+    # Produce a pseudo-infinite MC statistics template
+    # Create a MC set with 10000 times more stats than data. will be used as the truth
+    #
+    print('creating the infinite template')
+    infinite_toymc_params = copy.deepcopy(toymc_params)
+    infinite_toymc_params.stats_factor = 1000.
+    print(infinite_toymc_params.stats_factor)
+    mc_template_pseudo_infinite = create_mc_template(infinite_toymc_params, config_file=config_file, seed=mc_seed)
+    mc_map_pseudo_infinite = sum(mc_template_pseudo_infinite.get_outputs(return_sum=True, force_standard_output=False)['old_sum'])
+
+    X = toymc_params.binning.midpoints[0].magnitude
 
     fig, ax = plt.subplots(figsize=(7, 7))
     ax.errorbar(X, data_map.nominal_values, yerr=np.sqrt(data_map.nominal_values),
      label='data', fmt='-o', drawstyle='steps-mid', color='k')
-    ax.set_xlabel('Some variable')
-    ax.set_ylabel('Some counts')
-    ax.set_title('Pseudo data fed into the likelihoods')
-    ax.text(0.65, 0.9, r'$\mu_{true}$ = '+'{}'.format(TRUE_MU),
-            fontsize=12, transform=ax.transAxes)
+    ax.set_xlabel('Arbitrary variable')
+    ax.set_ylabel('Frequency (A.U.)')
+
+    ax.text(0.65, 0.91, r'$\mu_{true}$ = '+'{}'.format(TRUE_MU),
+            fontsize=20, transform=ax.transAxes)
     ax.text(0.65, 0.85, r'$\sigma_{true}$ = ' +
-            '{}'.format(TRUE_SIGMA), fontsize=12, transform=ax.transAxes)
-    ax.text(0.65, 0.8, r'$N_{signal}$ = '+'{}'.format(toymc_params.nsig),
-            fontsize=12, transform=ax.transAxes)
-    ax.text(0.65, 0.75, r'$N_{bkg}$ = '+'{}'.format(toymc_params.nbkg),
-            fontsize=12, transform=ax.transAxes)
+            '{}'.format(TRUE_SIGMA), fontsize=20, transform=ax.transAxes)
+    ax.text(0.65, 0.79, r'$N_{signal}$ = '+'{}'.format(toymc_params.nsig),
+            fontsize=20, transform=ax.transAxes)
+    ax.text(0.65, 0.73, r'$N_{bkg}$ = '+'{}'.format(toymc_params.nbkg),
+            fontsize=20, transform=ax.transAxes)
     ax.legend(loc='upper left')
+
     if interactive:
         plt.show()
-    output_pdf.savefig(fig)
+    if output_pdf is not None:
+        output_pdf.savefig(fig)
 
     #
     # Update the same plot with the low stats MC
     #
     ax.plot(X, mc_map.nominal_values, '-g', label='MC', drawstyle='steps-mid', zorder=10)
-    ax.text(0.65, 0.7, r'$\mu_{MC}$ = '+'{}'.format(
-        mc_params['mu'].value.m), color='g', fontsize=12, transform=ax.transAxes)
-    ax.text(0.65, 0.65, r'$\sigma_{MC}$ = '+'{}'.format(
-        mc_params['sigma'].value.m), color='g', fontsize=12, transform=ax.transAxes)
-    ax.text(0.65, 0.6, 'MC factor = {}'.format(
-        mc_params['stats_factor'].value.m), color='g', fontsize=12, transform=ax.transAxes)
+    ax.text(0.65, 0.67, r'$\mu_{MC}$ = '+'{}'.format(
+        mc_params['mu'].value.m), color='g', fontsize=20, transform=ax.transAxes)
+    ax.text(0.65, 0.61, r'$\sigma_{MC}$ = '+'{}'.format(
+        mc_params['sigma'].value.m), color='g', fontsize=20, transform=ax.transAxes)
+    ax.legend(loc='upper left')
+
+    ax.set_title('MC factor = {}'.format(mc_params['stats_factor'].value.m))
+    if interactive:
+        plt.show()
+    if output_pdf is not None:
+        output_pdf.savefig(fig)
+
+    #
+    # Update the same plot with the low stats MC modified for the generalized Poisson
+    #
+    ax.plot(X, mc_generalized_map.nominal_values, ':b', label='MC - Generalized', drawstyle='steps-mid', zorder=10)
     ax.legend(loc='upper left')
     if interactive:
         plt.show()
-    output_pdf.savefig(fig)
+    if output_pdf is not None:
+        output_pdf.savefig(fig)
 
     #
     # Update with the pseudo-infinite MC set
     #
     ax.plot(X, mc_map_pseudo_infinite.nominal_values,
             '-r', label='MC (large statistics)', drawstyle='steps-mid', zorder=10)
-    ax.text(0.65, 0.55, 'Inf. MC factor = {}'.format(mc_params_pseudo_infinite['stats_factor'].value.m), 
-            color='r', fontsize=12, transform=ax.transAxes)
     ax.legend(loc='upper left')
+
     if interactive:
         plt.show()
-    output_pdf.savefig(fig)
+    if output_pdf is not None:
+        output_pdf.savefig(fig)
 
 
 ##################################################################################
@@ -705,7 +812,6 @@ if __name__ == '__main__':
     import matplotlib.pyplot as plt
     from matplotlib.backends.backend_pdf import PdfPages
     import seaborn as sns
-    COLORS = sns.color_palette("hls", 8)
     output_pdf = PdfPages(args.output+'.pdf')
 
     #
@@ -726,60 +832,37 @@ if __name__ == '__main__':
     toymc_params.sigma = TRUE_SIGMA                  # True width of the signal
     toymc_params.nbackground_low = 0.                # lowest value the background can take
     toymc_params.nbackground_high = 40.              # highest value the background can take
-    toymc_params.binning = OneDimBinning(name='stuff', bin_edges=np.linspace(
-        toymc_params.nbackground_low, toymc_params.nbackground_high, NBINS))
+    toymc_params.binning = MultiDimBinning( OneDimBinning(name='stuff', bin_edges=np.linspace(
+        toymc_params.nbackground_low, toymc_params.nbackground_high, NBINS)))
     # Statistical factor for the MC
     toymc_params.stats_factor = args.stats_factor
-    toymc_params.infinite_stats = 10000
+    toymc_params.infinite_stats = 1000.
 
 
     metrics_to_test = ['llh', 'mcllh_eff','mod_chi2',
                        'mcllh_mean', 'generalized_poisson_llh']
 
-    results = collections.OrderedDict()
+    results = OrderedDict()
     results['toymc_params'] = toymc_params
     for metric in metrics_to_test:
-        results[metric] = collections.OrderedDict()
+        results[metric] = OrderedDict()
 
     # ==============================================================
     #
     # Generate a toy data set
     #
-    data_as_mapset = create_pseudo_data(toymc_params=toymc_params, seed=None)
+    data_as_mapset = create_pseudo_data(toymc_params=toymc_params, seed=564525)
 
-    # ===============================================================
-    #
-    # Generate MC template using a pisa pipeline
-    #
-    # We first need to override the parameter values contained in the config file
-    # before instantiating the pipeline
-    mc_template = create_mc_template(
-        toymc_params, config_file=STANDARD_CONFIG, seed=None)
-    mc_map = mc_template.get_outputs(return_sum=True)
-
-    # =================================================================
-    #
-    # Produce a pseudo-infinite MC statistics template
-    # Create a MC set with 10000 times more stats than data. will be used as the truth
-    #
-    infinite_toymc_params = copy.deepcopy(toymc_params)
-    infinite_toymc_params.stats_factor = toymc_params.infinite_stats
-    mc_template_pseudo_infinite = create_mc_template(
-        infinite_toymc_params, config_file=STANDARD_CONFIG, seed=None)
-    mc_map_pseudo_infinite = mc_template_pseudo_infinite.get_outputs(
-        return_sum=True)
+   
 
     # =================================================================
     #
     # Plot the three graphs
     #
     plot_data_and_mc(data_map=data_as_mapset.maps[0],
-                     mc_map=mc_map.maps[0],
-                     mc_params=mc_template.params,
-                     mc_map_pseudo_infinite=mc_map_pseudo_infinite.maps[0],
-                     mc_params_pseudo_infinite=mc_template_pseudo_infinite.params,
+                     config_file=STANDARD_CONFIG,
                      toymc_params=toymc_params,
-                     toymc_params_pseudo_infinite=infinite_toymc_params,
+                     mc_seed=564525,
                      interactive=args.interactive,
                      output_pdf=output_pdf)
 
@@ -789,8 +872,13 @@ if __name__ == '__main__':
     #
     if args.make_llh_scan:
 
-        results = run_llh_scans(metrics=metrics_to_test, mc_template=mc_template,
-                                data_mapset=data_as_mapset, results=results)
+        results = run_llh_scans(metrics=metrics_to_test,
+                                mc_params=toymc_params,
+                                config_file=STANDARD_CONFIG,
+                                data_mapset=data_as_mapset,
+                                mc_seed=564525,
+                                results=results)
+
         plot_llh_scans(metrics=metrics_to_test, results=results,
                        interactive=args.interactive, output_pdf=output_pdf)
 
@@ -802,8 +890,7 @@ if __name__ == '__main__':
 
         results = run_coverage_test(n_trials=args.ntrials,
                                     toymc_params=toymc_params,
-                                    mc_template=mc_template,
-                                    mc_infinite_stats=mc_template_pseudo_infinite,
+                                    config_file=STANDARD_CONFIG,
                                     metrics=metrics_to_test,
                                     results=results,
                                     output_stem=args.output,


### PR DESCRIPTION
This PR corrects a major flaw in the way I originally set up my simple 1D likelihood test. 

Initially, the pipeline I created in pi_simple_signal would generate, at every iteration of the minimizer, a completely new distribution of weights that were randomly distributed according to a gaussian signal. This meant that the actual locations of the weight within the analysis binning varied from iteration to iteration, which is not exactly what I intended to do.

Instead of doing the above, a single distribution of weights is now generated only once, at the setup phase of the stage. These weights are distributed uniformly over the chosen range of parameter values, and during a fit, a gaussian PDF is used to _re-weight_ the already generated weights. This is closer to the scenario we have in real life, as the location of weights in the analysis binning is fixed by the event reconstruction we get out of the simulation production.

This change has the added benefit of making the likelihoods_1D_test.py run much faster, and it also makes the code in pi_simple_signal a bit simpler.


Finally, I've also added two flags to pi_generalized_llh_params, which enable the user to turn on or off the use of pseudo-weights and mean adjustment in the generalized likelihood. When these two flags are set to False, the stage will no modify the input weights.